### PR TITLE
Include Grant and Accelerator/incubator in failure evaluation

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
@@ -46,15 +46,15 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_fundi
 
 STAGE_FAILURE_MAP = {
     "Grant": {
-        "at_stage_round_types": ["Grant", "Pre-Seed", "Seed"],
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
         "graduation_stages": ["Series A", "Early VC"],
     },
     "Pre-Seed": {
-        "at_stage_round_types": ["Grant", "Pre-Seed", "Seed"],
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
         "graduation_stages": ["Series A", "Early VC"],
     },
     "Seed": {
-        "at_stage_round_types": ["Grant", "Pre-Seed", "Seed"],
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
         "graduation_stages": ["Series A", "Early VC"],
     },
     "Series A": {
@@ -62,7 +62,7 @@ STAGE_FAILURE_MAP = {
         "graduation_stages": ["Series B"],
     },
     "Early VC": {
-        "at_stage_round_types": ["Series A", "Early VC", "Grant", "Pre-Seed", "Seed"],
+        "at_stage_round_types": ["Series A", "Early VC", "Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
         "graduation_stages": ["Series B"],
     },
     "Series B": {

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -6,7 +6,6 @@ def did_raise_venture(company_funding_rows):
 
 M_AND_A_SUCCESS_STAGE = "Series A"
 
-# Leaving out Grant because it's not a venture round
 EARLY_VC_STAGES = [
     "Early VC",
     "Pre-Seed",
@@ -18,6 +17,8 @@ EARLY_VC_STAGES = [
 LATE_VC_CUTOFF = "Series B"
 
 DISCLOSED_STAGES_ORDERED = [
+    "Accelerator/incubator",
+    "Grant",
     "Pre-Seed",
     "Seed",
     "Early VC",
@@ -107,6 +108,9 @@ def raised_equity_round(company_funding_rows):
     if "Equity" in financing_types:
         return True
     if "Grant" in financing_types:
+        return True
+    round_types = company_funding_rows['round_type_nzi'].values
+    if "Accelerator/incubator" in round_types:
         return True
     return False
 

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
@@ -132,6 +132,26 @@ GRANT_ONLY = make_rows([
     {"round_date_nzi": pd.Timestamp("2021-01-01"), "round_type_nzi": "Grant", "financing_type_nzi": "Grant"},
 ])
 
+GRANT_ONLY_RECENT = make_rows([
+    {"round_date_nzi": pd.Timestamp("2025-06-01"), "round_type_nzi": "Grant", "financing_type_nzi": "Grant"},
+])
+
+ACCELERATOR_ONLY_STALE = make_rows([
+    {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Accelerator/incubator", "financing_type_nzi": "Other"},
+])
+
+ACCELERATOR_PLUS_GRANT_STALE = make_rows([
+    {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Accelerator/incubator", "financing_type_nzi": "Other"},
+    {"round_date_nzi": pd.Timestamp("2021-08-01"), "round_type_nzi": "Grant", "financing_type_nzi": "Grant"},
+    {"round_date_nzi": pd.Timestamp("2022-01-18"), "round_type_nzi": "Grant", "financing_type_nzi": "Grant"},
+])
+
+ACCELERATOR_TO_SERIES_B = make_rows([
+    {"round_date_nzi": pd.Timestamp("2018-01-01"), "round_type_nzi": "Accelerator/incubator", "financing_type_nzi": "Other"},
+    {"round_date_nzi": pd.Timestamp("2019-01-01"), "round_type_nzi": "Seed", "financing_type_nzi": "Equity"},
+    {"round_date_nzi": pd.Timestamp("2021-01-01"), "round_type_nzi": "Series B", "financing_type_nzi": "Equity"},
+])
+
 
 # ---------------------------------------------------------------------------
 # Company row fixtures (mimic company details records)
@@ -153,6 +173,9 @@ class TestRaisedEquityRound:
 
     def test_grant_returns_true(self):
         assert raised_equity_round(GRANT_ONLY) is True
+
+    def test_accelerator_returns_true(self):
+        assert raised_equity_round(ACCELERATOR_ONLY_STALE) is True
 
     def test_debt_only_returns_false(self):
         assert raised_equity_round(DEBT_ONLY) is False
@@ -176,6 +199,12 @@ class TestRaisedStageOrEarlier:
             {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Series D", "financing_type_nzi": "Equity"},
         ])
         assert raised_stage_or_earlier(rows, stages=["Series A"]) is False
+
+    def test_grant_matches_early_vc(self):
+        assert raised_stage_or_earlier(GRANT_ONLY, stages=["Early VC"]) is True
+
+    def test_accelerator_matches_early_vc(self):
+        assert raised_stage_or_earlier(ACCELERATOR_ONLY_STALE, stages=["Early VC"]) is True
 
     def test_no_disclosed_stages(self):
         assert raised_stage_or_earlier(DEBT_ONLY, stages=["Series A"]) is False
@@ -275,9 +304,17 @@ class TestDidCompanyFail:
         """Equity gate: debt-only company cannot fail."""
         assert did_company_fail(DEBT_ONLY, COMPANY_OPERATING) is False
 
-    def test_never_reached_focal_stage_returns_false(self):
-        """Stage gate: company with only grants can't fail at Early VC threshold."""
-        assert did_company_fail(GRANT_ONLY, COMPANY_OPERATING) is False
+    def test_grant_only_stale_is_failure(self):
+        """Grant-only company, stale for 2+ years → failure at Early VC threshold."""
+        with self._patch_now() as mock_dt:
+            mock_dt.now.return_value = FIXED_NOW
+            assert did_company_fail(GRANT_ONLY, COMPANY_OPERATING) is True
+
+    def test_grant_only_recent_not_failure(self):
+        """Grant-only company with recent funding → not yet classifiable."""
+        with self._patch_now() as mock_dt:
+            mock_dt.now.return_value = FIXED_NOW
+            assert did_company_fail(GRANT_ONLY_RECENT, COMPANY_OPERATING) is False
 
     def test_already_succeeded_returns_false(self):
         """Success override: Bowery succeeded past Series B."""
@@ -308,6 +345,24 @@ class TestDidCompanyFail:
         with self._patch_now() as mock_dt:
             mock_dt.now.return_value = FIXED_NOW
             assert did_company_fail(IPO_COMPANY, COMPANY_OPERATING) is False
+
+    def test_accelerator_only_stale_is_failure(self):
+        """Accelerator-only company, stale for 2+ years → failure."""
+        with self._patch_now() as mock_dt:
+            mock_dt.now.return_value = FIXED_NOW
+            assert did_company_fail(ACCELERATOR_ONLY_STALE, COMPANY_OPERATING) is True
+
+    def test_accelerator_plus_grant_stale_is_failure(self):
+        """Accelerator + Grant company, stale → failure (like client 65539)."""
+        with self._patch_now() as mock_dt:
+            mock_dt.now.return_value = FIXED_NOW
+            assert did_company_fail(ACCELERATOR_PLUS_GRANT_STALE, COMPANY_OPERATING) is True
+
+    def test_accelerator_to_series_b_succeeds(self):
+        """Company starting at accelerator that reached Series B → not failure."""
+        with self._patch_now() as mock_dt:
+            mock_dt.now.return_value = FIXED_NOW
+            assert did_company_fail(ACCELERATOR_TO_SERIES_B, COMPANY_OPERATING) is False
 
 
 class TestDidCompanyFailThresholds:


### PR DESCRIPTION
## Summary
- Grant-only and accelerator-only companies were previously excluded from stage-based failure classification because these round types weren't in `DISCLOSED_STAGES_ORDERED`
- Added `Accelerator/incubator` and `Grant` to `DISCLOSED_STAGES_ORDERED`, `STAGE_FAILURE_MAP`, and `raised_equity_round`
- Companies like client 65539 (only grants + accelerator, stale since 2022) are now correctly marked as failures

## Test plan
- [x] All 47 tests pass (up from 39), including 8 new tests for grant/accelerator scenarios
- [ ] Verify failure rate counts in the notebook reflect the newly classified companies

🤖 Generated with [Claude Code](https://claude.com/claude-code)