### PR TITLE
Cut GivingTuesday consumer over to gt_datamart + server-side aggregation speedup

### DIFF
--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -97,39 +97,60 @@ def query_basic_fields_db_for_eins(
     return df
 
 
-def query_unioned_grants_for_eins(
+def query_grant_summaries_for_eins(
     client,
     eins_list,
     filter_yr=2017,
 ):
-    logger.info(f"Querying unioned grants for {len(eins_list)} EINs")
-    grants = client.get_grants(eins_list, role='grantee', min_taxyear=filter_yr)
-    if not grants:
+    """Server-side aggregated grants for ``eins_list``.
+
+    One row per ``(grantee_ein, taxyear)`` with the same totals + funder
+    rollups the downstream pivot needs, so we never pay the wire cost of
+    moving raw grant rows the caller immediately groups away.
+    """
+    logger.info(f"Querying grant summaries for {len(eins_list)} EINs")
+    summaries = client.get_grant_summaries(eins_list, role='grantee', min_taxyear=filter_yr)
+    if not summaries:
         return pd.DataFrame(columns=[
-            'granter_ein', 'granter_name', 'grantee_ein', 'taxyear', 'grant_amount',
+            'grantee_ein', 'taxyear', 'total_grant_amount', 'grant_count',
+            'granter_eins', 'granter_names',
         ])
-    df = pd.DataFrame.from_records([asdict(g) for g in grants])
-    logger.info(f"Found {len(df)} grants for {len(eins_list)} EINs")
+    df = pd.DataFrame.from_records([asdict(s) for s in summaries])
+    df.rename(columns={'ein': 'grantee_ein'}, inplace=True)
+    logger.info(f"Found {len(df)} (EIN, year) grant summaries for {len(eins_list)} EINs")
     return df
 
 
 def filter_format_grants_data(
-    grants_data,
+    grant_summaries,
     avg_yearly_funding_min=0, # Require they received a grant in any year but don't require a minimum amount
 ):
+    """Pivot the per-(EIN, year) summaries into the wide ``grant_YYYY`` form.
+
+    ``grant_summaries`` already has one row per ``(grantee_ein, taxyear)``
+    with ``total_grant_amount`` summed server-side. The funder columns are
+    deduped per year on the server, so the final ``Funders`` / ``Funder_Names``
+    sets are just unions across years.
+    """
     logger.info(f"Filtering and formatting grants data")
-    grants_data = grants_data.copy()
-    avg_yearly_funding = grants_data.groupby(['grantee_ein', 'taxyear'])['grant_amount'].sum().groupby('grantee_ein').mean().reset_index()
+    grant_summaries = grant_summaries.copy()
 
-    filtered_eins = avg_yearly_funding[avg_yearly_funding['grant_amount'] >= avg_yearly_funding_min]['grantee_ein'].tolist()
-    filtered_grants_data = grants_data[grants_data['grantee_ein'].isin(filtered_eins)]
+    avg_yearly_funding = (
+        grant_summaries
+        .groupby('grantee_ein')['total_grant_amount']
+        .mean()
+        .reset_index()
+    )
+    filtered_eins = avg_yearly_funding[
+        avg_yearly_funding['total_grant_amount'] >= avg_yearly_funding_min
+    ]['grantee_ein'].tolist()
+    filtered = grant_summaries[grant_summaries['grantee_ein'].isin(filtered_eins)]
 
-    max_funding_year = filtered_grants_data.groupby('grantee_ein')['taxyear'].max().to_dict()
-    annual_funding = filtered_grants_data.groupby(['grantee_ein', 'taxyear'])['grant_amount'].sum().reset_index()
-    funding_df = annual_funding.pivot_table(
+    max_funding_year = filtered.groupby('grantee_ein')['taxyear'].max().to_dict()
+    funding_df = filtered.pivot_table(
         index='grantee_ein',
         columns='taxyear',
-        values='grant_amount',
+        values='total_grant_amount',
         aggfunc='first',
     )
     funding_df = funding_df.fillna(0)
@@ -141,8 +162,17 @@ def filter_format_grants_data(
     funding_df.reset_index(inplace=True)
     funding_df['last_grant_year'] = funding_df['grantee_ein'].map(max_funding_year)
 
-    funder_data = filtered_grants_data.groupby(['grantee_ein']).agg({"granter_ein": set, "granter_name": set}).reset_index()
-    funder_data.rename(columns={"granter_ein": "Funders", "granter_name": "Funder_Names"}, inplace=True)
+    # Union across years — server already deduped within each year.
+    funder_data = (
+        filtered
+        .groupby('grantee_ein')
+        .agg({
+            'granter_eins': lambda series: sorted({e for arr in series for e in (arr or [])}),
+            'granter_names': lambda series: sorted({n for arr in series for n in (arr or [])}),
+        })
+        .reset_index()
+        .rename(columns={'granter_eins': 'Funders', 'granter_names': 'Funder_Names'})
+    )
 
     funding_df = funding_df.merge(funder_data, left_on='grantee_ein', right_on='grantee_ein', how='left')
     logger.info(f"Merged funder data with funding data")
@@ -282,7 +312,7 @@ def query_process_givingtuesday_data(
 ):
     client = client or _make_default_client()
 
-    # Get us potential EINs that match the search results
+    # 1) FTS over nonprofit_text → candidate EIN universe.
     search_results = search_for_eins(
         client=client,
         search_terms_list=search_terms_list,
@@ -290,29 +320,49 @@ def query_process_givingtuesday_data(
         return_full_text=return_full_text,
         search_mode=search_mode,
     )
+    candidate_eins = search_results['filerein'].unique().tolist()
+    ein_to_full_text = dict(search_results[['filerein', 'full_text']].values)
 
-    grants_data = query_unioned_grants_for_eins(
+    # 2) Push the avg-contributions threshold into Postgres so we don't pull
+    #    multi-year basic_fields rows for EINs we'll discard. With the default
+    #    avg_yearly_contributions_min=300000 this typically prunes the EIN
+    #    universe ~5-10x. NOTE: this changes behavior vs. the prior LEFT-join
+    #    flow, where below-threshold EINs survived to output with NaN contribs
+    #    columns. They're now dropped — which appears to be the intent of the
+    #    threshold parameter.
+    if avg_yearly_contributions_min and avg_yearly_contributions_min > 0:
+        eligible_eins = client.find_eins_with_min_avg_contributions(
+            candidate_eins,
+            min_taxyear=filter_yr,
+            min_avg=avg_yearly_contributions_min,
+        )
+    else:
+        eligible_eins = candidate_eins
+
+    # 3) basic_fields for the (now smaller) eligible set.
+    all_data_long = query_basic_fields_db_for_eins(client, eligible_eins, filter_yr=filter_yr)
+
+    # 4) Server-side aggregated grants for the same eligible set.
+    grant_summaries_df = query_grant_summaries_for_eins(
         client,
-        search_results['filerein'].tolist(),
+        eligible_eins,
         filter_yr=filter_yr,
     )
     grants_funding_df = filter_format_grants_data(
-        grants_data,
-        avg_yearly_funding_min=avg_yearly_funding_grants_min
+        grant_summaries_df,
+        avg_yearly_funding_min=avg_yearly_funding_grants_min,
     )
 
+    # 5) require_one_grant narrows the basic_fields rows to EINs that had a
+    #    grant survive the avg_yearly_funding_grants_min filter above.
     if require_one_grant:
-        # Get the EINs that have grants and contributions over the minimums
-        eins_list = grants_funding_df['grantee_ein'].unique().tolist()
-    else:
-        eins_list = search_results['filerein'].unique().tolist()
-    ein_to_full_text = dict(search_results[['filerein', 'full_text']].values)
-    all_data_long = query_basic_fields_db_for_eins(client, eins_list, filter_yr=filter_yr)
+        kept = set(grants_funding_df['grantee_ein'].unique().tolist())
+        all_data_long = all_data_long[all_data_long['filerein'].isin(kept)]
 
     total_cash_contributions_df = filter_format_funding_data(
         all_data_long,
         column='total_cash_contributions',
-        avg_yearly_contributions_min=avg_yearly_contributions_min
+        avg_yearly_contributions_min=avg_yearly_contributions_min,
     )
 
     all_data_reformatted = reformat_basic_fields_data(

--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -37,6 +37,7 @@ def search_for_eins(
     client,
     search_terms_list=None,
     search_terms_path=None,
+    search_mode='exact',
     return_full_text=False,
 ):
     """Return EINs whose ``nonprofit_text`` matches any of the keywords.
@@ -50,7 +51,7 @@ def search_for_eins(
     else:
         keywords = pd.read_csv(search_terms_path)['term'].tolist()
 
-    hits = client.search_nonprofits(keywords, return_text=return_full_text)
+    hits = client.search_nonprofits(keywords, return_text=return_full_text, search_mode=search_mode)
     if not hits:
         return pd.DataFrame(columns=['filerein', 'full_text'])
 
@@ -264,6 +265,7 @@ def reformat_ein(filerein):
 def query_process_givingtuesday_data(
     search_terms_list=None,
     search_terms_path=None,
+    search_mode='exact',
     proceessed_output_path=None,
     require_one_grant=True,
     filter_yr=2017,
@@ -281,6 +283,7 @@ def query_process_givingtuesday_data(
         search_terms_list=search_terms_list,
         search_terms_path=search_terms_path,
         return_full_text=return_full_text,
+        search_mode=search_mode,
     )
 
     grants_data = query_unioned_grants_for_eins(

--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -1,83 +1,113 @@
+"""Build the Giving Tuesday CB-shaped DataFrame for ed-tracker / similar pipelines.
+
+Cut over to gt_datamart via ``givingtuesday_datamart.client``: keyword search
+runs as Postgres FTS over ``public.nonprofit_text.text_tsv`` (replacing the
+S3 parquet + FlashText path), and the per-EIN basic-fields / grants reads go
+through the typed client surface.
+"""
+
+from dataclasses import asdict
+
 import pandas as pd
-from sqlalchemy import text
-from vdl_tools.shared_tools.project_config import get_paths
+from vdl_tools.shared_tools.tools.config_utils import get_configuration
 from vdl_tools.shared_tools.tools.logger import logger
-from vdl_tools.shared_tools.database_cache.database_utils import get_session
-from vdl_tools.shared_tools.keyword_extraction.search_term_recall_calculations import run_keyword_extraction
-import vdl_tools.shared_tools.parquet_cache as pq_cache
+
+from givingtuesday_datamart.client import GtDatamartClient
+
+
+def _make_default_client() -> GtDatamartClient:
+    """Build a GtDatamartClient from vdl-tools' postgres config.
+
+    The client itself does not depend on vdl-tools (so it is shippable as a
+    standalone package); this adapter lives on the vdl-tools side and maps
+    ``get_configuration()`` to the client's component args. Database is
+    pinned to ``gt_datamart`` regardless of what the local config has set.
+    """
+    pg = get_configuration()["postgres"]
+    return GtDatamartClient(
+        host=pg["host"],
+        port=pg["port"],
+        user=pg["user"],
+        password=pg["password"],
+        database="gt_datamart",
+    )
 
 
 def search_for_eins(
-    nonprofits_with_text_df_uri,
+    client,
     search_terms_list=None,
     search_terms_path=None,
 ):
+    """Return EINs whose ``nonprofit_text`` matches any of the keywords.
 
-    logger.info(f"Searching for EINs with search terms")
+    Output DataFrame uses ``filerein`` and ``concat_text`` to keep the
+    downstream pivot/reformat helpers untouched (those were written against
+    the old parquet's column names).
+    """
+    logger.info("Searching for EINs with search terms")
     if not any([search_terms_list, search_terms_path]):
         raise ValueError("Must provide either search_terms_list or search_terms_path")
 
     if search_terms_list:
-        nonprofit_search_terms = search_terms_list
+        keywords = search_terms_list
     else:
-        nonprofit_search_terms_df = pd.read_csv(search_terms_path)
-        nonprofit_search_terms = nonprofit_search_terms_df['term'].tolist()
+        keywords = pd.read_csv(search_terms_path)['term'].tolist()
 
-    nonprofits_with_text_df = pq_cache.read_dataframe(uri=nonprofits_with_text_df_uri)
-    results = run_keyword_extraction(
-        keywords=nonprofit_search_terms,
-        df=nonprofits_with_text_df,
-        text_field="concat_text",
-    )
-    results = results[results['KW_Extracted_Len'] > 0]
+    hits = client.search_nonprofits(keywords)
+    if not hits:
+        return pd.DataFrame(columns=['filerein', 'concat_text'])
+
+    results = pd.DataFrame.from_records([
+        {'filerein': h.ein, 'concat_text': h.unique_text or ''} for h in hits
+    ])
     logger.info(f"Found {len(results)} EINs with search terms")
     return results
 
 
 def query_basic_fields_db_for_eins(
+    client,
     eins_list,
     filter_yr=2017,
 ):
-    with get_session() as session:
-        query = text("""
-            SELECT
-                filerein::text,
-                filername1,
-                filername2,
-                taxyear,
-                filerus1,
-                filerus2,
-                fileruscity,
-                filerusstate,
-                fileruszip,
-                websitsiteit,
-                totrevcuryea AS total_revenue_current_year,
-                totacashcont AS total_cash_contributions,
-                totacashcont - governgrants AS total_cash_contributions_no_gov
-            FROM irs_filings.basic_fields
-            WHERE filerein::text = ANY(:eins_list)
-            AND taxyear >= :filter_yr
-            """)
-        cur = session.execute(query, {"eins_list": eins_list, "filter_yr": filter_yr})
-        results = pd.DataFrame(cur.fetchall(), columns=cur.keys())
-        return results
+    rows = client.get_basic_fields(eins_list, min_taxyear=filter_yr)
+    if not rows:
+        return pd.DataFrame(columns=[
+            'filerein', 'filername1', 'filername2', 'taxyear',
+            'filerus1', 'filerus2', 'fileruscity', 'filerusstate', 'fileruszip',
+            'websitsiteit',
+            'total_revenue_current_year', 'total_cash_contributions',
+            'total_cash_contributions_no_gov',
+        ])
+    df = pd.DataFrame.from_records([asdict(r) for r in rows])
+    # Restore the old column names downstream pivot/reformat helpers expect.
+    df.rename(columns={
+        'ein': 'filerein',
+        'name': 'filername1',
+        'name_secondary': 'filername2',
+        'addr_line_1': 'filerus1',
+        'addr_line_2': 'filerus2',
+        'city': 'fileruscity',
+        'state': 'filerusstate',
+        'zip': 'fileruszip',
+        'website': 'websitsiteit',
+    }, inplace=True)
+    return df
+
 
 def query_unioned_grants_for_eins(
+    client,
     eins_list,
     filter_yr=2017,
 ):
     logger.info(f"Querying unioned grants for {len(eins_list)} EINs")
-    with get_session() as session:
-        query = text("""
-            SELECT *
-            FROM irs_filings.unioned_grants
-            WHERE grantee_ein::text = ANY(:eins_list)
-            AND taxyear >= :filter_yr
-            """)
-        cur = session.execute(query, {"eins_list": eins_list, "filter_yr": filter_yr})
-        results = pd.DataFrame(cur.fetchall(), columns=cur.keys())
-        logger.info(f"Found {len(results)} grants for {len(eins_list)} EINs")
-        return results
+    grants = client.get_grants(eins_list, role='grantee', min_taxyear=filter_yr)
+    if not grants:
+        return pd.DataFrame(columns=[
+            'granter_ein', 'granter_name', 'grantee_ein', 'taxyear', 'grant_amount',
+        ])
+    df = pd.DataFrame.from_records([asdict(g) for g in grants])
+    logger.info(f"Found {len(df)} grants for {len(eins_list)} EINs")
+    return df
 
 
 def filter_format_grants_data(
@@ -229,21 +259,24 @@ def reformat_ein(filerein):
 
 
 def query_process_givingtuesday_data(
-    nonprofits_with_text_df_uri,
     search_terms_list=None,
     search_terms_path=None,
     proceessed_output_path=None,
     filter_yr=2017,
     column_for_funding='total_cash_contributions',
+    client=None,
 ):
+    client = client or _make_default_client()
+
     # Get us potential EINs that match the search results
     search_results = search_for_eins(
-        nonprofits_with_text_df_uri=nonprofits_with_text_df_uri,
+        client=client,
         search_terms_list=search_terms_list,
         search_terms_path=search_terms_path,
     )
 
     grants_data = query_unioned_grants_for_eins(
+        client,
         search_results['filerein'].tolist(),
         filter_yr=filter_yr,
     )
@@ -252,7 +285,7 @@ def query_process_givingtuesday_data(
     # Get the EINs that have grants and contributions over the minimums
     eins_list = grants_funding_df['grantee_ein'].tolist()
     ein_to_full_text = dict(search_results[['filerein', 'concat_text']].values)
-    all_data_long = query_basic_fields_db_for_eins(eins_list, filter_yr=filter_yr)
+    all_data_long = query_basic_fields_db_for_eins(client, eins_list, filter_yr=filter_yr)
 
     total_cash_contributions_df = filter_format_funding_data(
         all_data_long,
@@ -269,14 +302,14 @@ def query_process_givingtuesday_data(
         ],
         column_for_funding=column_for_funding,
     )
-    all_data_reformatted.to_json(proceessed_output_path, orient='records')
+    if proceessed_output_path:
+        all_data_reformatted.to_json(proceessed_output_path, orient='records')
     return all_data_reformatted
 
 
 if __name__ == "__main__":
     filter_yr = 2023
     query_process_givingtuesday_data(
-        nonprofits_with_text_df_uri="s3://ed-tracker-data/givingtuesday/giving_tuesday_all_text_fields.parquet",
         search_terms_list=["teachers", "education"],
         # search_terms_path=paths['nonprofit_search_terms'],
         proceessed_output_path="s3://ed-tracker-data/givingtuesday/giving_tuesday_data_cleaned.json",

--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -1,9 +1,8 @@
 """Build the Giving Tuesday CB-shaped DataFrame for ed-tracker / similar pipelines.
 
-Cut over to gt_datamart via ``givingtuesday_datamart.client``: keyword search
-runs as Postgres FTS over ``public.nonprofit_text.text_tsv`` (replacing the
-S3 parquet + FlashText path), and the per-EIN basic-fields / grants reads go
-through the typed client surface.
+Keyword search runs as Postgres FTS over ``public.nonprofit_text.text_tsv``,
+and the per-EIN basic-fields / grants reads go through the typed
+``givingtuesday_datamart.client`` surface.
 """
 
 from dataclasses import asdict
@@ -82,7 +81,9 @@ def query_basic_fields_db_for_eins(
             'total_cash_contributions_no_gov',
         ])
     df = pd.DataFrame.from_records([asdict(r) for r in rows])
-    # Restore the old column names downstream pivot/reformat helpers expect.
+    # Downstream pivot/reformat helpers read the IRS 990 column names
+    # (``filerein``, ``filername1``, ``filerus1``, …) directly off the
+    # DataFrame, so map the client's clean field names onto those.
     df.rename(columns={
         'ein': 'filerein',
         'name': 'filername1',
@@ -326,10 +327,8 @@ def query_process_givingtuesday_data(
     # 2) Push the avg-contributions threshold into Postgres so we don't pull
     #    multi-year basic_fields rows for EINs we'll discard. With the default
     #    avg_yearly_contributions_min=300000 this typically prunes the EIN
-    #    universe ~5-10x. NOTE: this changes behavior vs. the prior LEFT-join
-    #    flow, where below-threshold EINs survived to output with NaN contribs
-    #    columns. They're now dropped — which appears to be the intent of the
-    #    threshold parameter.
+    #    universe ~5-10x. EINs whose avg falls below the threshold are
+    #    dropped from output entirely (not nulled out).
     if avg_yearly_contributions_min and avg_yearly_contributions_min > 0:
         eligible_eins = client.find_eins_with_min_avg_contributions(
             candidate_eins,

--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -37,12 +37,9 @@ def search_for_eins(
     client,
     search_terms_list=None,
     search_terms_path=None,
+    return_full_text=False,
 ):
     """Return EINs whose ``nonprofit_text`` matches any of the keywords.
-
-    Output DataFrame uses ``filerein`` and ``concat_text`` to keep the
-    downstream pivot/reformat helpers untouched (those were written against
-    the old parquet's column names).
     """
     logger.info("Searching for EINs with search terms")
     if not any([search_terms_list, search_terms_path]):
@@ -53,12 +50,12 @@ def search_for_eins(
     else:
         keywords = pd.read_csv(search_terms_path)['term'].tolist()
 
-    hits = client.search_nonprofits(keywords)
+    hits = client.search_nonprofits(keywords, return_text=return_full_text)
     if not hits:
-        return pd.DataFrame(columns=['filerein', 'concat_text'])
+        return pd.DataFrame(columns=['filerein', 'full_text'])
 
     results = pd.DataFrame.from_records([
-        {'filerein': h.ein, 'concat_text': h.unique_text or ''} for h in hits
+        {'filerein': h.ein, 'full_text': h.unique_text or ''} for h in hits
     ])
     logger.info(f"Found {len(results)} EINs with search terms")
     return results
@@ -188,7 +185,12 @@ def reformat_basic_fields_data(
 
     basic_fields_data['Description'] = basic_fields_data['filerein'].map(ein_to_full_text)
     for join_key, funding_df in funding_dfs:
-        basic_fields_data = basic_fields_data.merge(funding_df, left_on='filerein', right_on=join_key)
+        basic_fields_data = basic_fields_data.merge(
+            funding_df,
+            left_on='filerein',
+            right_on=join_key,
+            how='left',
+        )
         if join_key != 'filerein':
             basic_fields_data.drop(columns=[join_key], inplace=True)
 
@@ -245,6 +247,7 @@ def reformat_basic_fields_data(
 
     return basic_fields_data
 
+
 def reformat_ein(filerein):
     if len(filerein) == 10:
         if '-' not in filerein:
@@ -262,9 +265,13 @@ def query_process_givingtuesday_data(
     search_terms_list=None,
     search_terms_path=None,
     proceessed_output_path=None,
+    require_one_grant=True,
     filter_yr=2017,
+    avg_yearly_contributions_min=300000,
+    avg_yearly_funding_grants_min=0,
     column_for_funding='total_cash_contributions',
     client=None,
+    return_full_text=True,
 ):
     client = client or _make_default_client()
 
@@ -273,6 +280,7 @@ def query_process_givingtuesday_data(
         client=client,
         search_terms_list=search_terms_list,
         search_terms_path=search_terms_path,
+        return_full_text=return_full_text,
     )
 
     grants_data = query_unioned_grants_for_eins(
@@ -280,17 +288,23 @@ def query_process_givingtuesday_data(
         search_results['filerein'].tolist(),
         filter_yr=filter_yr,
     )
-    grants_funding_df = filter_format_grants_data(grants_data, avg_yearly_funding_min=0)
+    grants_funding_df = filter_format_grants_data(
+        grants_data,
+        avg_yearly_funding_min=avg_yearly_funding_grants_min
+    )
 
-    # Get the EINs that have grants and contributions over the minimums
-    eins_list = grants_funding_df['grantee_ein'].tolist()
-    ein_to_full_text = dict(search_results[['filerein', 'concat_text']].values)
+    if require_one_grant:
+        # Get the EINs that have grants and contributions over the minimums
+        eins_list = grants_funding_df['grantee_ein'].unique().tolist()
+    else:
+        eins_list = search_results['filerein'].unique().tolist()
+    ein_to_full_text = dict(search_results[['filerein', 'full_text']].values)
     all_data_long = query_basic_fields_db_for_eins(client, eins_list, filter_yr=filter_yr)
 
     total_cash_contributions_df = filter_format_funding_data(
         all_data_long,
         column='total_cash_contributions',
-        avg_yearly_contributions_min=300000
+        avg_yearly_contributions_min=avg_yearly_contributions_min
     )
 
     all_data_reformatted = reformat_basic_fields_data(

--- a/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
+++ b/vdl_tools/scrape_enrich/givingtuesday/query_prepare_givingtuesday.py
@@ -11,6 +11,7 @@ from dataclasses import asdict
 import pandas as pd
 from vdl_tools.shared_tools.tools.config_utils import get_configuration
 from vdl_tools.shared_tools.tools.logger import logger
+from vdl_tools.shared_tools.parquet_cache import write_dataframe
 
 from givingtuesday_datamart.client import GtDatamartClient
 
@@ -51,7 +52,11 @@ def search_for_eins(
     else:
         keywords = pd.read_csv(search_terms_path)['term'].tolist()
 
-    hits = client.search_nonprofits(keywords, return_text=return_full_text, search_mode=search_mode)
+    hits = client.search_nonprofits(
+        keywords,
+        return_text=return_full_text,
+        search_mode=search_mode,
+    )
     if not hits:
         return pd.DataFrame(columns=['filerein', 'full_text'])
 
@@ -320,7 +325,7 @@ def query_process_givingtuesday_data(
         column_for_funding=column_for_funding,
     )
     if proceessed_output_path:
-        all_data_reformatted.to_json(proceessed_output_path, orient='records')
+        write_dataframe(all_data_reformatted, proceessed_output_path)
     return all_data_reformatted
 
 

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_survival_rates.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_survival_rates.py
@@ -30,7 +30,7 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_fundi
 from vdl_tools.shared_tools.funding_calcations import create_plot_get_metrics
 
 # Stages evaluated in the survival pipeline (maps to CB's seed → series_a → late_venture)
-NZI_SURVIVAL_STAGES = ["Seed", "Early VC", "Series B"]
+NZI_SURVIVAL_STAGES = ["Seed", "Series A", "Series B"]
 
 # Round types that count as being at "seed" level for cohort classification
 _SEED_LEVEL_TYPES = {"Accelerator/incubator", "Grant", "Pre-Seed", "Seed"}


### PR DESCRIPTION
## Summary

Cuts the GivingTuesday consumer over to the `gt_datamart` client surface and speeds it up. End-to-end runtime on the 258-keyword ed-tracker invocation: **11m30s → 2m40s (4.3x)**.

Two functional changes:

1. **Cutover** (commit [`06c0fd1`](../../commit/06c0fd1)) — replace the OLD VDL DB SQL (`irs_filings.basic_fields` / `irs_filings.unioned_grants`) and the S3-parquet + FlashText keyword search with a single `GtDatamartClient` surface (Postgres FTS over `public.nonprofit_text`, typed methods for `basic_fields` / grants).
2. **Speedup** (commit [`dd5b2ec`](../../commit/dd5b2ec)) — reorder the pipeline so the avg-contributions threshold filters EINs in Postgres *before* the grants pull, and replace the raw `get_grants` pull with the new server-side aggregated `get_grant_summaries` endpoint. Depends on [givingtuesday-datamart#21](https://github.com/vibrant-data-labs/givingtuesday-datamart/pull/21).

## Behavior change vs the WIP build

The intermediate WIP commits on this branch had `how='left'` joins in `reformat_basic_fields_data`, which meant EINs whose `avg_yearly_total_cash_contributions` fell below `avg_yearly_contributions_min` (default 300K) stayed in output with NaN contribs columns. After this PR, those EINs are **dropped**. This matches the **legacy** `previous_query_prepare_givingtuesday.py` semantic (which used INNER joins) — the WIP behavior was the anomaly, not legacy.

Row count comparison on the 258-keyword run:
- Legacy (`previous_query_prepare_givingtuesday.py`, OLD VDL DB): 70,789 rows
- WIP intermediate (LEFT joins): 125,890 rows
- This PR: 70,069 rows

The ~1% gap vs legacy is search-source delta (FTS exact-mode vs FlashText). All other downstream values are bit-identical to legacy where the same EIN appears in both outputs:
- 0 / 551,160 mismatches on per-year contribs cells
- 0 / 68,895 mismatches on `total_total_cash_contributions`, `Total_Funding_$`, `Last_Funding_Year`
- Per-EIN grant totals match each pipeline's source DB exactly (10/10 EINs checked)

Grant-value divergence between legacy and this PR is data drift between OLD VDL DB and gt_datamart (gt_datamart has more recent / more complete ingest), not a code logic difference.

## Verification

- Live smoke against `gt_datamart` (2-keyword and 258-keyword runs)
- Full diff vs legacy output (`previous_query_prepare_givingtuesday.py`) — see numbers above
- `require_one_grant=False` path verified end-to-end: 77,648 rows, 70K with grants + 7.6K without

## Heads-up: one unrelated change

Commit [`ba951e3`](../../commit/ba951e3) ("wip") includes a one-line stage-name fix in `vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_survival_rates.py` — `"Early VC"` → `"Series A"` in `NZI_SURVIVAL_STAGES`. Looks intentional but is unrelated to the GT cutover. Flagging in case you want to split it out before squash-merging.

## Follow-ups (out of scope for this PR)

- `search_nonprofits` could grow `min_avg_contributions` / `min_num_grants` params so the two-call eligibility dance (FTS → contribs filter) collapses to one round trip. Issue to be filed.
- `query_process_givingtuesday_data` itself still carries old VDL DB column-name shims (`filerein`, `filername1`, `websitsiteit`) just to feed downstream pivot/reformat helpers — a from-scratch rewrite on the new client surface is ~150 lines smaller. Issue to be filed.
- Canonical-tables unification ([givingtuesday-datamart#22](https://github.com/vibrant-data-labs/givingtuesday-datamart/issues/22)) would let the grants COALESCE collapse to a single LEFT JOIN.
