### PR TITLE
Consolidate NZI constants + late_to_exit period expansion + graduation predicate fixes (Growth equity, exit cohorts)

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/funding_round.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/funding_round.py
@@ -1,6 +1,10 @@
 import pandas as pd
 from vdl_tools.shared_tools.tools.text_cleaning import camel_to_snake
 
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
+    M_AND_A_NAMES,
+)
+
 
 
 FUNDING_ROUND_COLUMNS = [
@@ -33,13 +37,6 @@ FUNDING_ROUND_COLUMNS = [
     # "infrastructureProjectID",
     "roundNews",
 ]
-
-
-ACQUISITION_ROUND_TYPES = {
-    'Merger',
-    "Acquisition",
-    "Buyout",
-}
 
 
 def filter_format_columns(
@@ -162,7 +159,7 @@ def was_acquired_merged(
     round_type_col: str = 'roundType',
 ):
     company_round_types = company_funding_rows[round_type_col].values
-    company_acquisition_events = ACQUISITION_ROUND_TYPES.intersection(company_round_types)
+    company_acquisition_events = set(M_AND_A_NAMES).intersection(company_round_types)
     return len(company_acquisition_events) > 0
 
 def add_acquisition_indicators(

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_survival_rates.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_survival_rates.py
@@ -14,33 +14,22 @@ import numpy as np
 import pandas as pd
 
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.nzi_zombie_companies_fail import (
-    STAGE_FAILURE_MAP,
     did_company_fail,
     did_company_succeed,
 )
-from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_funding_rounds import (
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
+    A_TO_B_TYPES,
     EXIT_TYPES,
     LATE_STAGE_TYPES,
     LATE_VC_CUTOFF,
     M_AND_A_SUCCESS_STAGE,
     MIDDLE_STAGE_TYPES,
+    NZI_SURVIVAL_STAGES,
+    SEED_COHORT_TYPES,
+    STAGE_FAILURE_MAP,
     TWO_YEARS_IN_DAYS,
 )
 from vdl_tools.shared_tools.funding_calcations import create_plot_get_metrics
-
-# Stages evaluated in the survival pipeline (maps to CB's seed → series_a → late_venture).
-# Each stage uses STAGE_FAILURE_MAP[<stage>]["at_stage_round_types"] as the
-# membership gate: a company is only in a stage's cohort if it actually had
-# a round of one of those types. With "Series A" (rather than "Early VC"),
-# only companies that raised a Series A or Early VC round count as A-stage
-# members — seed-only companies are excluded from `series_a_*` flags.
-NZI_SURVIVAL_STAGES = ["Seed", "Series A", "Series B"]
-
-# Round types that count as being at "seed" level for cohort classification
-_SEED_LEVEL_TYPES = {"Accelerator/incubator", "Grant", "Pre-Seed", "Seed"}
-
-# Round types that indicate early VC level (Series A / Early VC)
-_EARLY_VC_LEVEL_TYPES = {"Series A", "Early VC"}
 
 
 # ---------------------------------------------------------------------------
@@ -52,8 +41,7 @@ def _classify_company_current_stage(company_funding_rows):
 
     Examines the ``round_type_nzi`` values in the company's funding rounds
     and returns the highest stage bucket the company has reached, using
-    the module-level ``_SEED_LEVEL_TYPES``, ``_EARLY_VC_LEVEL_TYPES``, and
-    the stage sets from ``split_early_late_funding_rounds``.
+    the stage sets from ``stage_constants``.
 
     Parameters
     ----------
@@ -75,9 +63,9 @@ def _classify_company_current_stage(company_funding_rows):
 
     if round_types & (MIDDLE_STAGE_TYPES | LATE_STAGE_TYPES | EXIT_TYPES):
         return "series_b+"
-    if round_types & _EARLY_VC_LEVEL_TYPES:
+    if round_types & A_TO_B_TYPES:
         return "early_vc"
-    if round_types & _SEED_LEVEL_TYPES:
+    if round_types & SEED_COHORT_TYPES:
         return "seed"
     return None
 

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
@@ -26,6 +26,7 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_fundi
 )
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
     DISCLOSED_STAGES_ORDERED,
+    EXIT_TYPES,
     LATE_VC_CUTOFF,
     M_AND_A_NAMES,
     M_AND_A_SUCCESS_STAGE,
@@ -54,6 +55,19 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
         (sometimes alone, sometimes after Series A/B/C). Treated as graduation
         anywhere late venture or Series A+ would count.
 
+    Exit-cohort suppression
+    -----------------------
+    When ``graduation_stages`` consists entirely of exit types (IPO / SPAC /
+    Post IPO / Post IPO - Equity), as for the ``Late_Exit`` and ``Seed_Exit``
+    cohorts, NO catch-all is appended. Late VC and Growth equity are
+    late-venture rounds, not exits — appending them to the graduation set of
+    an exit cohort would silently classify any company that raised a late
+    venture round (without actually exiting) as "succeeded at exit", inflating
+    the Late_Exit / Seed_Exit success rate. The IPO / M&A paths in
+    ``did_company_succeed`` handle real exits separately; the suppression here
+    just keeps the catch-all auto-append from over-extending the graduation
+    set for cohorts whose graduation is genuinely "did they exit?".
+
     Parameters
     ----------
     graduation_stages : list[str]
@@ -69,17 +83,25 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
     list[str]
         All stage names at or after the earliest graduation stage, potentially
         with one or more of ``"Late VC"``, ``"Growth equity"``, ``"Early VC"``
-        appended.
+        appended (none appended for exit cohorts).
 
     Examples
     --------
     >>> _get_graduation_and_later_stages(["Series B"], "Series B")
     ["Series B", "Series C", ..., "Post IPO - Equity", "Late VC", "Growth equity"]
+    >>> _get_graduation_and_later_stages(
+    ...     ["IPO", "Post IPO", "Post IPO - Equity", "SPAC"], "Series B")
+    ["IPO", "SPAC", "Post IPO", "Post IPO - Equity"]   # NO catch-all
     """
     earliest_graduation_idx = min(
         DISCLOSED_STAGES_ORDERED.index(stage) for stage in graduation_stages
     )
     stages_at_or_after = DISCLOSED_STAGES_ORDERED[earliest_graduation_idx:]
+
+    # Suppress the catch-all auto-append for exit cohorts (Late_Exit, Seed_Exit).
+    # See the "Exit-cohort suppression" section in the docstring for why.
+    if set(graduation_stages).issubset(set(EXIT_TYPES)):
+        return stages_at_or_after
 
     late_venture_stages = DISCLOSED_STAGES_ORDERED[
         DISCLOSED_STAGES_ORDERED.index(late_venture_cutoff):

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
@@ -22,64 +22,16 @@ Key inputs:
 import datetime as dt
 
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_funding_rounds import (
+    raised_equity_round,
+)
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
     DISCLOSED_STAGES_ORDERED,
     LATE_VC_CUTOFF,
     M_AND_A_NAMES,
     M_AND_A_SUCCESS_STAGE,
+    STAGE_FAILURE_MAP,
     TWO_YEARS_IN_DAYS,
-    raised_equity_round,
-    LATE_STAGE_TYPES,
-    EXIT_TYPES,
 )
-
-
-# ---------------------------------------------------------------------------
-# Stage mapping for failure evaluation
-# ---------------------------------------------------------------------------
-# When evaluating failure "at_stage", we need to know:
-#   - which round types count as "having reached that stage" (at_stage_round_types)
-#   - which round types prove they graduated past it (graduation_stages)
-#
-# Example: at_stage="Series A"
-#   at_stage_round_types = ["Series A", "Early VC"]
-#       → any of these mean the company was in the early stage
-#   graduation_stages = ["Series B"]
-#       → raising Series B means they succeeded past early stage
-
-STAGE_FAILURE_MAP = {
-    "Pre-Seed": {
-        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed"],
-        "graduation_stages": ["Seed", "Series A", "Early VC"],
-    },
-    "Seed": {
-        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
-        "graduation_stages": ["Series A", "Early VC"],
-    },
-    "Series A": {
-        "at_stage_round_types": ["Series A", "Early VC"],
-        "graduation_stages": ["Series B"],
-    },
-    "Early VC": {
-        "at_stage_round_types": ["Series A", "Early VC", "Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
-        "graduation_stages": ["Series B"],
-    },
-    "Series B": {
-        "at_stage_round_types": ["Series B"],
-        "graduation_stages": ["Late VC", "Series C"],
-    },
-    "Late_Exit": {
-        "at_stage_round_types": list(LATE_STAGE_TYPES),
-        # M&A names are handled separately by `_has_successful_manda` and are
-        # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
-        "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
-    },
-    "Seed_Exit": {
-        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
-        # M&A names are handled separately by `_has_successful_manda` and are
-        # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
-        "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
-    },
-}
 
 
 def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
@@ -74,9 +74,14 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
         Stage names that define the graduation threshold (e.g. ``["Series B"]``).
         Must all be present in ``DISCLOSED_STAGES_ORDERED``.
     late_venture_cutoff : str
-        The stage at or after which rounds are considered "late venture".
-        Used to decide whether the ``"Late VC"`` / ``"Growth equity"`` aliases
-        should be included.  Comes from ``stage_constants.LATE_VC_CUTOFF``.
+        Graduation-set inclusion floor: if ``graduation_stages`` overlaps the
+        slice ``DISCLOSED_STAGES_ORDERED[idx(late_venture_cutoff):]``, the
+        catch-all ``"Late VC"`` / ``"Growth equity"`` labels are appended.
+        Comes from ``stage_constants.LATE_VC_CUTOFF`` (default ``"Series B"``).
+        Despite the name, this is NOT a taxonomic definition of "where late
+        venture begins" — it's the threshold at which a cohort's graduation
+        set should include late-VC catch-alls. See ``stage_constants.py`` for
+        the contrast with ``MIDDLE_STAGE_TYPES``.
 
     Returns
     -------

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/nzi_zombie_companies_fail.py
@@ -39,9 +39,20 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
 
     Given a list of graduation stages, returns those stages plus every stage
     that comes after them in ``DISCLOSED_STAGES_ORDERED``.  Also appends the
-    catch-all labels ``"Late VC"`` or ``"Early VC"`` when the graduation
-    threshold overlaps their range, since those labels are not part of the
-    natural ordering but can appear in funding round data.
+    catch-all labels ``"Late VC"``, ``"Growth equity"``, or ``"Early VC"`` when
+    the graduation threshold overlaps their range, since those labels are not
+    part of the natural ordering but can appear in funding round data.
+
+    Empirical context for the catch-alls:
+
+      - ``"Early VC"`` ≈ Series A: NZI uses them interchangeably for the same
+        funding event (see Elemental skill's gotcha #1).
+      - ``"Late VC"`` ≈ Series C+ without a specific letter; almost always
+        appears alongside at least one numbered late series.
+      - ``"Growth equity"`` is structurally different — large equity infusion
+        for a growth-stage company, used across many funnel positions
+        (sometimes alone, sometimes after Series A/B/C). Treated as graduation
+        anywhere late venture or Series A+ would count.
 
     Parameters
     ----------
@@ -50,19 +61,20 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
         Must all be present in ``DISCLOSED_STAGES_ORDERED``.
     late_venture_cutoff : str
         The stage at or after which rounds are considered "late venture".
-        Used to decide whether the ``"Late VC"`` alias should be included.
-        Comes from ``split_early_late_funding_rounds.LATE_VC_CUTOFF``.
+        Used to decide whether the ``"Late VC"`` / ``"Growth equity"`` aliases
+        should be included.  Comes from ``stage_constants.LATE_VC_CUTOFF``.
 
     Returns
     -------
     list[str]
         All stage names at or after the earliest graduation stage, potentially
-        with ``"Late VC"`` or ``"Early VC"`` appended.
+        with one or more of ``"Late VC"``, ``"Growth equity"``, ``"Early VC"``
+        appended.
 
     Examples
     --------
     >>> _get_graduation_and_later_stages(["Series B"], "Series B")
-    ["Series B", "Series C", ..., "Post IPO - Equity", "Late VC"]
+    ["Series B", "Series C", ..., "Post IPO - Equity", "Late VC", "Growth equity"]
     """
     earliest_graduation_idx = min(
         DISCLOSED_STAGES_ORDERED.index(stage) for stage in graduation_stages
@@ -73,12 +85,16 @@ def _get_graduation_and_later_stages(graduation_stages, late_venture_cutoff):
         DISCLOSED_STAGES_ORDERED.index(late_venture_cutoff):
     ]
 
-    # "Late VC" and "Early VC" are catch-all labels not in DISCLOSED_STAGES_ORDERED's
-    # natural position — include them when the graduation threshold overlaps their range
+    # ``Late VC`` / ``Growth equity`` / ``Early VC`` are catch-all labels not in
+    # DISCLOSED_STAGES_ORDERED's natural position — include them when the
+    # graduation threshold overlaps their range. ``Growth equity`` is appended
+    # wherever ``Late VC`` would be (it's a late-stage equity instrument, see
+    # docstring), so that a company with [Series A, Growth equity] correctly
+    # counts as graduated past Series A.
     if set(graduation_stages).intersection(late_venture_stages):
-        return stages_at_or_after + ["Late VC"]
+        return stages_at_or_after + ["Late VC", "Growth equity"]
     if set(graduation_stages).intersection(["Series A", "Early VC"]):
-        return stages_at_or_after + ["Early VC"]
+        return stages_at_or_after + ["Early VC", "Growth equity"]
 
     return stages_at_or_after
 

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -12,6 +12,15 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import
     UP_TO_A_TYPES,
 )
 
+# Buckets that get per-investor-type count columns. ("exit" is excluded)
+INVESTOR_COUNT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+
+# Buckets that get equity / non-equity split columns. ("exit" is excluded)
+EQUITY_SPLIT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+
+# Buckets that get a per-stage `{stage}_investors` list-of-dicts column.
+INVESTOR_LIST_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+
 
 def did_raise_venture(company_funding_rows):
     """Check whether a company has raised venture (equity) funding.
@@ -163,18 +172,6 @@ def divide_funding_rows(
         "late_to_exit":    split[3],
         "exit":    split[4],
     }
-
-# Buckets that get per-investor-type count columns. Pre-Series-B funding is
-# the analytical focus, so we count investors in the two pre-B buckets plus
-# `b_to_late` (so callers can study Series-B-stage investors as well).
-INVESTOR_COUNT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late"}
-
-# Buckets that get equity / non-equity split columns. Same pre-B focus as
-# INVESTOR_COUNT_BUCKETS — late_to_exit and exit are excluded.
-EQUITY_SPLIT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late"}
-
-# Buckets that get a per-stage `{stage}_investors` list-of-dicts column.
-INVESTOR_LIST_BUCKETS = {"up_to_a", "a_to_b", "b_to_late"}
 
 
 def _collect_investor_types(primary, secondary):

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -12,14 +12,18 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import
     UP_TO_A_TYPES,
 )
 
-# Buckets that get per-investor-type count columns. ("exit" is excluded)
-INVESTOR_COUNT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+# Periods that get the per-investor-type count columns (one count column per investor type:
+# ``{period}_has_<type>_investor_calced_nzi_count``). "exit" is intentionally excluded.
+PERIODS_WITH_INVESTOR_TYPE_COUNTS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
 
-# Buckets that get equity / non-equity split columns. ("exit" is excluded)
-EQUITY_SPLIT_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+# Periods that get the per-financing-type breakdown columns (equity_raised / nonequity_raised /
+# debt_raised / grant_raised / project_finance_raised / convertible_note_raised plus per-type
+# round counts — 13 columns total). "exit" is intentionally excluded.
+PERIODS_WITH_FINANCING_TYPE_COLS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
 
-# Buckets that get a per-stage `{stage}_investors` list-of-dicts column.
-INVESTOR_LIST_BUCKETS = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
+# Periods that get the per-period ``{period}_investors`` list-of-dicts column (one dict per
+# unique investor seen in any round in that period). "exit" is intentionally excluded.
+PERIODS_WITH_INVESTOR_LIST = {"up_to_a", "a_to_b", "b_to_late", "late_to_exit"}
 
 
 def did_raise_venture(company_funding_rows):
@@ -273,7 +277,7 @@ def divided_funding_rows_and_flatten(
         Investor metadata (output of ``process_nzi_investors``) with
         ``investor_id_nzi``, ``name_nzi``, ``primary_type_nzi``, and
         ``secondary_types_nzi``. When provided, each bucket in
-        ``INVESTOR_LIST_BUCKETS`` gets a ``{stage}_investors`` column
+        ``PERIODS_WITH_INVESTOR_LIST`` gets a ``{stage}_investors`` column
         containing a deduped list of
         ``{"id", "name", "investor_types"}`` dicts (``investor_types``
         merges primary + secondary types). When ``None`` (default), the
@@ -285,9 +289,9 @@ def divided_funding_rows_and_flatten(
         One row per company with columns prefixed by stage name (e.g.
         ``up_to_a_first_round_date``, ``a_to_b_amount_raised``,
         ``b_to_late_num_rounds``, ``exit_last_round_date``). Buckets in
-        ``INVESTOR_COUNT_BUCKETS`` also get
+        ``PERIODS_WITH_INVESTOR_TYPE_COUNTS`` also get
         ``*_has_<type>_investor_calced_nzi_count`` columns. Buckets in
-        ``EQUITY_SPLIT_BUCKETS`` additionally get
+        ``PERIODS_WITH_FINANCING_TYPE_COLS`` additionally get
         ``*_equity_raised`` (sum of ``Equity`` financing-type rounds),
         ``*_nonequity_raised`` (sum of all other rounds — grants, debt,
         convertibles, etc.), ``*_n_rounds_equity`` / ``*_n_rounds_nonequity``
@@ -298,7 +302,7 @@ def divided_funding_rows_and_flatten(
         the NaN guard, which fires when every round of a given type in
         the bucket was undisclosed). When
         ``processed_investor_df`` is provided, buckets in
-        ``INVESTOR_LIST_BUCKETS`` also get ``*_investors`` — a deduped
+        ``PERIODS_WITH_INVESTOR_LIST`` also get ``*_investors`` — a deduped
         list of ``{"id", "name", "investor_types"}`` dicts covering every
         investor across the bucket's rounds.
     """
@@ -329,13 +333,13 @@ def divided_funding_rows_and_flatten(
                 "all_funding_activity": None,
             }
             # Investor counts only for the two pre-B buckets.
-            if round_name in INVESTOR_COUNT_BUCKETS:
+            if round_name in PERIODS_WITH_INVESTOR_TYPE_COUNTS:
                 round_group_dict.update({f"{col}_count": None for col in investor_type_columns})
             # Equity / non-equity split only for pre-B buckets. The
             # debt / grant / project-finance entries are extra line items
             # carved out of the nonequity rows so analyses can pull them
             # out separately (not a re-bucketing).
-            if round_name in EQUITY_SPLIT_BUCKETS:
+            if round_name in PERIODS_WITH_FINANCING_TYPE_COLS:
                 round_group_dict["equity_raised"] = None
                 round_group_dict["nonequity_raised"] = None
                 round_group_dict["n_rounds_equity"] = None
@@ -349,7 +353,7 @@ def divided_funding_rows_and_flatten(
                 round_group_dict["n_rounds_grant"] = None
                 round_group_dict["n_rounds_project_finance"] = None
                 round_group_dict["n_rounds_convertible_note"] = None
-            if include_investor_lists and round_name in INVESTOR_LIST_BUCKETS:
+            if include_investor_lists and round_name in PERIODS_WITH_INVESTOR_LIST:
                 round_group_dict["investors"] = None
 
             if round_group_rounds is None:
@@ -366,10 +370,10 @@ def divided_funding_rows_and_flatten(
             # so downstream means treat the bucket as missing, not as $0.
             if round_group_dict["num_rounds"] > 0 and round_group_dict["amount_raised"] == 0:
                 round_group_dict["amount_raised"] = float("nan")
-            if round_name in INVESTOR_COUNT_BUCKETS:
+            if round_name in PERIODS_WITH_INVESTOR_TYPE_COUNTS:
                 for investor_type_col in investor_type_columns:
                     round_group_dict[f"{investor_type_col}_count"] = round_group_rounds[investor_type_col].sum()
-            if round_name in EQUITY_SPLIT_BUCKETS:
+            if round_name in PERIODS_WITH_FINANCING_TYPE_COLS:
                 is_equity = round_group_rounds['financing_type_nzi'] == "Equity"
                 equity_rows = round_group_rounds[is_equity]
                 nonequity_rows = round_group_rounds[~is_equity]
@@ -424,7 +428,7 @@ def divided_funding_rows_and_flatten(
                 ):
                     if round_group_dict[_n_key] > 0 and round_group_dict[_amt_key] == 0:
                         round_group_dict[_amt_key] = float("nan")
-            if include_investor_lists and round_name in INVESTOR_LIST_BUCKETS:
+            if include_investor_lists and round_name in PERIODS_WITH_INVESTOR_LIST:
                 round_group_dict["investors"] = _bucket_investors(
                     round_group_rounds, investor_lookup
                 )

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -1,6 +1,17 @@
 import datetime as dt
 import pandas as pd
 
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
+    A_TO_B_TYPES,
+    EXIT_TYPES,
+    LATE_STAGE_TYPES,
+    MIDDLE_STAGE_TYPES,
+    SPLIT_AFTER_LAST_EARLY_ROUND,
+    SPLIT_ON_FIRST_LATE_ROUND,
+    STAGE_ORDER,
+    UP_TO_A_TYPES,
+)
+
 
 def did_raise_venture(company_funding_rows):
     """Check whether a company has raised venture (equity) funding.
@@ -17,96 +28,6 @@ def did_raise_venture(company_funding_rows):
         True if any row has ``financing_type_nzi == "Equity"``.
     """
     return "Equity" in company_funding_rows['financing_type_nzi'].values
-
-
-M_AND_A_SUCCESS_STAGE = "Series A"
-
-EARLY_VC_STAGES = [
-    "Early VC",
-    "Pre-Seed",
-    "Seed",
-    "Series A",
-]
-
-# Anything Series B or later is considered a late venture round
-LATE_VC_CUTOFF = "Series B"
-
-DISCLOSED_STAGES_ORDERED = [
-    "Accelerator/incubator",
-    "Grant",
-    "Pre-Seed",
-    "Seed",
-    "Early VC",
-    "Series A",
-    "Series B",
-    "Series C",
-    "Late VC",
-    "Series D",
-    "Series E",
-    "Series F",
-    "Series G",
-    "Series H",
-    "Series I",
-    "Series J",
-    "IPO",
-    "SPAC",
-    "Post IPO",
-    "Post IPO - Equity",
-]
-
-M_AND_A_NAMES = [
-    "Merger",
-    "Acquisition",
-    "Buyout",
-]
-
-SPLIT_ON_FIRST_LATE_ROUND = "first_late_round"
-SPLIT_AFTER_LAST_EARLY_ROUND = "after_last_early_round"
-
-
-TWO_YEARS_IN_DAYS = 365 * 2
-
-# Stage classification sets — only equity venture rounds define boundaries.
-# The pre-Series-B window is split into two finer buckets:
-#   up_to_a = rounds before the first Series A or Early VC round
-#   a_to_b  = rounds from first Series A / Early VC up to first Series B
-UP_TO_A_TYPES = {
-    "Pre-Seed",
-    "Seed",
-}
-
-A_TO_B_TYPES = {
-    "Series A",
-    "Early VC",
-}
-
-MIDDLE_STAGE_TYPES = {
-    "Series B",
-    # "Late VC",  # moved to late stage - usually follows C or is synonymous with C
-}
-
-LATE_STAGE_TYPES = {
-    "Late VC",
-    "Series C",
-    "Series D",
-    "Series E",
-    "Series F",
-    "Series G",
-    "Series H",
-    "Series I",
-    "Series J",
-    "Growth equity",
-}
-
-EXIT_TYPES = {
-    "IPO",
-    "SPAC",
-    "Post IPO",
-    "Post IPO - Equity",
-    "Merger",
-    "Acquisition",
-    "Buyout",
-}
 
 
 def _get_effective_stage(round_type):
@@ -137,9 +58,6 @@ def _get_effective_stage(round_type):
     if round_type in EXIT_TYPES:
         return "exit"
     return None
-
-
-STAGE_ORDER = {"up_to_a": 0, "a_to_b": 1, "b_to_late": 2, "late_to_exit": 3, "exit": 4}
 
 
 def raised_equity_round(company_funding_rows):

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -124,7 +124,29 @@ EXIT_TYPES = {
 # ---------------------------------------------------------------------------
 # 4. Stage boundaries
 # ---------------------------------------------------------------------------
-# Anything Series B or later is considered a late venture round.
+# Graduation-set inclusion floor used by ``_get_graduation_and_later_stages``
+# in ``nzi_zombie_companies_fail.py``: if a cohort's ``graduation_stages``
+# overlap the slice ``DISCLOSED_STAGES_ORDERED[idx(LATE_VC_CUTOFF):]``, the
+# catch-all venture labels ``"Late VC"`` and ``"Growth equity"`` are appended
+# to the graduation set. Set to ``"Series B"`` so that a Series A cohort
+# (graduation_stages = ["Series B"]) sweeps in those catch-alls — a company
+# with ``[Series A → Late VC]`` or ``[Series A → Growth equity]`` then
+# correctly counts as graduated past Series A.
+#
+# NOTE: do NOT confuse this with ``MIDDLE_STAGE_TYPES = {"Series B"}`` (which
+# answers a different question: what BUCKET does a Series B round land in?
+# Answer: the middle / b_to_late bucket, not a late one). The two constants
+# encode different decisions:
+#
+#   - ``MIDDLE_STAGE_TYPES`` is taxonomic: where does Series B sit in the
+#     funding-round bucket ordering? Middle.
+#   - ``LATE_VC_CUTOFF`` is a graduation-set trigger threshold: at which
+#     graduation level should we start treating Late VC / Growth equity as
+#     plausible graduation outcomes? Series B graduation → yes.
+#
+# Both are correct for what they're asking. Renaming has been discussed but
+# left for a wider naming pass to avoid ripple through three modules; the
+# docstring here is the authoritative description of the constant's role.
 LATE_VC_CUTOFF = "Series B"
 
 # Earliest stage at which an M&A event counts as a success rather than an

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -154,9 +154,8 @@ SPLIT_AFTER_LAST_EARLY_ROUND = "after_last_early_round"
 # ---------------------------------------------------------------------------
 # 7. Timing thresholds
 # ---------------------------------------------------------------------------
-# A company with no funding for this many days is flagged as a "zombie"
-# (stale) failure by `did_company_fail`. Also used downstream in
-# elemental-catalytic-capital as the OUTLIER_TIME cutoff.
+# A company with no funding for this many days is flagged as a "zombie" (stale) failure by `did_company_fail`.
+# Also used downstream in elemental-catalytic-capital as the OUTLIER_TIME cutoff.
 TWO_YEARS_IN_DAYS = 365 * 2
 
 

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -1,0 +1,225 @@
+"""Single source of truth for NZI stage / round / exit / timing constants.
+
+Every constant here defines part of the policy that the rest of the
+``process_nzi`` package (and downstream analyses) uses to slice funding-round
+data into stage buckets, classify round types as exits, and decide how long
+without funding counts as "zombie / stale". If you need to change any of
+these, change them here — everywhere else imports from this file.
+
+Sections:
+    1. Ordered stage sequence       (DISCLOSED_STAGES_ORDERED)
+    2. Stage groupings / buckets    (UP_TO_A_TYPES, A_TO_B_TYPES, etc.)
+    3. Exit and M&A round types     (EXIT_TYPES, M_AND_A_NAMES)
+    4. Stage boundaries             (LATE_VC_CUTOFF, M_AND_A_SUCCESS_STAGE)
+    5. Bucket ordering              (STAGE_ORDER)
+    6. Split-strategy enums         (SPLIT_ON_FIRST_LATE_ROUND, ...)
+    7. Timing thresholds            (TWO_YEARS_IN_DAYS)
+    8. Survival-pipeline stages     (NZI_SURVIVAL_STAGES)
+    9. Per-stage success/failure    (STAGE_FAILURE_MAP)
+"""
+
+# ---------------------------------------------------------------------------
+# 1. Ordered stage sequence
+# ---------------------------------------------------------------------------
+# Canonical order of NZI ``round_type_nzi`` values from earliest to latest.
+# Used to compare two stages ("is Series C later than Series B?") and to slice
+# "everything at or after the graduation stage" in the failure logic.
+# Note: "Early VC", "Late VC", and "Growth equity" are catch-all labels that
+# are NOT in this ordering — they are handled as aliases at call sites
+# (see _get_graduation_and_later_stages and _has_successful_manda).
+DISCLOSED_STAGES_ORDERED = [
+    "Accelerator/incubator",
+    "Grant",
+    "Pre-Seed",
+    "Seed",
+    "Early VC",
+    "Series A",
+    "Series B",
+    "Series C",
+    "Late VC",
+    "Series D",
+    "Series E",
+    "Series F",
+    "Series G",
+    "Series H",
+    "Series I",
+    "Series J",
+    "IPO",
+    "SPAC",
+    "Post IPO",
+    "Post IPO - Equity",
+]
+
+
+# ---------------------------------------------------------------------------
+# 2. Stage groupings / buckets
+# ---------------------------------------------------------------------------
+# Pre-Series-B funding is split into two finer buckets:
+#   up_to_a = rounds before the first Series A or Early VC round
+#   a_to_b  = rounds from first Series A / Early VC up to first Series B
+# Series B is its own bucket (b_to_late). Anything from Series C / Late VC /
+# Growth equity onward is late stage (late_to_exit). IPO / SPAC / M&A is exit.
+UP_TO_A_TYPES = {
+    "Pre-Seed",
+    "Seed",
+}
+
+A_TO_B_TYPES = {
+    "Series A",
+    "Early VC",
+}
+
+MIDDLE_STAGE_TYPES = {
+    "Series B",
+    # "Late VC",  # moved to late stage - usually follows C or is synonymous with C
+}
+
+LATE_STAGE_TYPES = {
+    "Late VC",
+    "Series C",
+    "Series D",
+    "Series E",
+    "Series F",
+    "Series G",
+    "Series H",
+    "Series I",
+    "Series J",
+    "Growth equity",
+}
+
+# Cohort membership set for "seed-stage" classification. Broader than UP_TO_A_TYPES because it also counts
+# pre-equity activity (accelerator, grant) as seed-level. Used both for ``STAGE_FAILURE_MAP["Seed"]`` (and
+# ``Seed_Exit``) and for the survival-pipeline current-stage classifier.
+SEED_COHORT_TYPES = {
+    "Accelerator/incubator",
+    "Grant",
+    "Pre-Seed",
+    "Seed",
+}
+
+
+# ---------------------------------------------------------------------------
+# 3. Exit and M&A round types
+# ---------------------------------------------------------------------------
+# M&A names are also part of EXIT_TYPES — they're broken out as a list so
+# downstream code can distinguish M&A specifically (e.g. early acqui-hire
+# detection in _has_successful_manda).
+M_AND_A_NAMES = [
+    "Merger",
+    "Acquisition",
+    "Buyout",
+]
+
+EXIT_TYPES = {
+    "IPO",
+    "SPAC",
+    "Post IPO",
+    "Post IPO - Equity",
+    "Merger",
+    "Acquisition",
+    "Buyout",
+}
+
+
+# ---------------------------------------------------------------------------
+# 4. Stage boundaries
+# ---------------------------------------------------------------------------
+# Anything Series B or later is considered a late venture round.
+LATE_VC_CUTOFF = "Series B"
+
+# Earliest stage at which an M&A event counts as a success rather than an
+# early acqui-hire failure. (Default for `did_company_succeed` / `did_company_fail`.)
+M_AND_A_SUCCESS_STAGE = "Series A"
+
+
+# ---------------------------------------------------------------------------
+# 5. Bucket ordering
+# ---------------------------------------------------------------------------
+# Ordinal positions of the five stage buckets, used to compare buckets
+# (e.g. "is `b_to_late` at or above `a_to_b`?").
+STAGE_ORDER = {"up_to_a": 0, "a_to_b": 1, "b_to_late": 2, "late_to_exit": 3, "exit": 4}
+
+
+# ---------------------------------------------------------------------------
+# 6. Split-strategy enums
+# ---------------------------------------------------------------------------
+# Two strategies for assigning rounds to the a_to_b bucket:
+#   first_late_round       : a_to_b ends at the first Series B round.
+#   after_last_early_round : a_to_b ends after the LAST Series A / Early VC
+#                            round (so interleaved Bs stay in the a_to_b bucket).
+SPLIT_ON_FIRST_LATE_ROUND = "first_late_round"
+SPLIT_AFTER_LAST_EARLY_ROUND = "after_last_early_round"
+
+
+# ---------------------------------------------------------------------------
+# 7. Timing thresholds
+# ---------------------------------------------------------------------------
+# A company with no funding for this many days is flagged as a "zombie"
+# (stale) failure by `did_company_fail`. Also used downstream in
+# elemental-catalytic-capital as the OUTLIER_TIME cutoff.
+TWO_YEARS_IN_DAYS = 365 * 2
+
+
+# ---------------------------------------------------------------------------
+# 8. Survival-pipeline stages
+# ---------------------------------------------------------------------------
+# Stages evaluated in the survival-rate pipeline (Seed → Series A → Series B
+# funnel). Each stage uses STAGE_FAILURE_MAP[<stage>]["at_stage_round_types"]
+# as the cohort gate — a company is only in the stage's cohort if it actually
+# had a round of one of those types. Using "Series A" (rather than "Early VC")
+# means only companies with a Series A OR Early VC round count as A-stage
+# members; seed-only companies are excluded.
+NZI_SURVIVAL_STAGES = ["Seed", "Series A", "Series B"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Per-stage success / failure map
+# ---------------------------------------------------------------------------
+# When evaluating failure "at_stage", we need to know:
+#   - which round types count as "having reached that stage"
+#     (at_stage_round_types)
+#   - which round types prove they graduated past it
+#     (graduation_stages)
+#
+# Example: at_stage="Series A"
+#   at_stage_round_types = ["Series A", "Early VC"]
+#       → any of these mean the company was in the early stage
+#   graduation_stages = ["Series B"]
+#       → raising Series B means they succeeded past early stage
+#
+# Synthetic keys ("Late_Exit", "Seed_Exit") are NOT in DISCLOSED_STAGES_ORDERED
+# and are used purely as STAGE_FAILURE_MAP keys for downstream reporting.
+STAGE_FAILURE_MAP = {
+    "Pre-Seed": {
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed"],
+        "graduation_stages": ["Seed", "Series A", "Early VC"],
+    },
+    "Seed": {
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
+        "graduation_stages": ["Series A", "Early VC"],
+    },
+    "Series A": {
+        "at_stage_round_types": ["Series A", "Early VC"],
+        "graduation_stages": ["Series B"],
+    },
+    "Early VC": {
+        "at_stage_round_types": ["Series A", "Early VC", "Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
+        "graduation_stages": ["Series B"],
+    },
+    "Series B": {
+        "at_stage_round_types": ["Series B"],
+        "graduation_stages": ["Late VC", "Series C"],
+    },
+    "Late_Exit": {
+        "at_stage_round_types": list(LATE_STAGE_TYPES),
+        # M&A names are handled separately by `_has_successful_manda` and are
+        # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
+        "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
+    },
+    "Seed_Exit": {
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
+        # M&A names are handled separately by `_has_successful_manda` and are
+        # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
+        "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
+    },
+}

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_funding_round_processing.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_funding_round_processing.py
@@ -1137,10 +1137,12 @@ def test_flatten_equity_nonequity_split_per_stage():
     assert out_b["a_to_b_n_rounds_nonequity"] == 0
     assert out_b["a_to_b_nonequity_types"] == []
 
-    # late_to_exit / exit buckets do NOT get the equity-split columns.
-    for absent in ("late_to_exit_equity_raised", "exit_equity_raised",
-                   "late_to_exit_nonequity_raised", "exit_nonequity_raised",
-                   "late_to_exit_nonequity_types", "exit_nonequity_types"):
+    # ``late_to_exit`` now gets the per-financing-type breakdown (it's in
+    # PERIODS_WITH_FINANCING_TYPE_COLS); ``exit`` remains intentionally narrow.
+    for present in ("late_to_exit_equity_raised", "late_to_exit_nonequity_raised",
+                    "late_to_exit_nonequity_types"):
+        assert present in out.columns
+    for absent in ("exit_equity_raised", "exit_nonequity_raised", "exit_nonequity_types"):
         assert absent not in out.columns
 
 

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_funding_round_processing.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_funding_round_processing.py
@@ -1,10 +1,12 @@
 import pandas as pd
 
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.split_early_late_funding_rounds import (
-    SPLIT_AFTER_LAST_EARLY_ROUND,
-    SPLIT_ON_FIRST_LATE_ROUND,
     divide_funding_rows,
     divided_funding_rows_and_flatten,
+)
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
+    SPLIT_AFTER_LAST_EARLY_ROUND,
+    SPLIT_ON_FIRST_LATE_ROUND,
 )
 
 

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_survival_rates.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_survival_rates.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.nzi_survival_rates import (
-    NZI_SURVIVAL_STAGES,
     _classify_company_current_stage,
     _precompute_company_classifications,
     _aggregate_from_precomputed,
@@ -18,6 +17,9 @@ from vdl_tools.scrape_enrich.netzero_insights.process_nzi.nzi_survival_rates imp
     calculate_failure_rate,
     calculate_expected_survivals,
     compare_survival_rates,
+)
+from vdl_tools.scrape_enrich.netzero_insights.process_nzi.stage_constants import (
+    NZI_SURVIVAL_STAGES,
 )
 
 

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
@@ -347,17 +347,23 @@ class TestGetGraduationAndLaterStages:
         assert "Early VC" in result
         assert "Growth equity" in result   # new
 
-    def test_exit_graduation_still_includes_late_vc_and_growth_equity(self):
-        # Late_Exit's threshold = exit types. Late VC and Growth equity are
-        # still appended (the auto-append fires whenever graduation overlaps
-        # late_venture_stages). Note: this is a known over-inclusion for the
-        # Late_Exit cohort that flags as a separate cleanup.
+    def test_exit_graduation_suppresses_catch_all_auto_append(self):
+        # Late_Exit / Seed_Exit graduation = exit types only. NO catch-all
+        # auto-append should fire — Late VC and Growth equity are late-venture
+        # rounds, not exits. Appending them to an exit-cohort graduation set
+        # would silently classify late-venture companies that never actually
+        # exited as "succeeded at exit". The auto-append suppression keeps the
+        # graduation set strictly exit-typed.
         result = _get_graduation_and_later_stages(
             ["IPO", "Post IPO", "Post IPO - Equity", "SPAC"], "Series B",
         )
         assert "IPO" in result
-        assert "Late VC" in result
-        assert "Growth equity" in result
+        assert "SPAC" in result
+        assert "Post IPO" in result
+        assert "Post IPO - Equity" in result
+        assert "Late VC" not in result
+        assert "Growth equity" not in result
+        assert "Early VC" not in result
 
 
 # ===========================================================================

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from vdl_tools.scrape_enrich.netzero_insights.process_nzi.nzi_zombie_companies_fail import (
+    _get_graduation_and_later_stages,
     did_company_fail,
     did_company_succeed,
     raised_stage_or_earlier,
@@ -155,6 +156,27 @@ RECENT_SEED_ONLY = make_rows([
     {"round_date_nzi": pd.Timestamp("2024-06-01"), "round_type_nzi": "Seed", "financing_type_nzi": "Equity"},
 ])
 
+# ---- Growth equity fixtures ----
+# "Growth equity" is a catch-all NZI label for late-stage equity rounds without a
+# specific Series letter. It is NOT in DISCLOSED_STAGES_ORDERED but is treated as
+# graduation alongside Late VC / Early VC catch-alls. These fixtures cover the
+# combinations that broke pre-fix (cf reports/2026-05-25 in elemental-catalytic-capital).
+
+SERIES_A_TO_GROWTH_EQUITY = make_rows([
+    {"round_date_nzi": pd.Timestamp("2018-01-01"), "round_type_nzi": "Series A",      "financing_type_nzi": "Equity"},
+    {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Growth equity", "financing_type_nzi": "Equity"},
+])
+
+SEED_TO_GROWTH_EQUITY = make_rows([
+    {"round_date_nzi": pd.Timestamp("2018-01-01"), "round_type_nzi": "Seed",          "financing_type_nzi": "Equity"},
+    {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Growth equity", "financing_type_nzi": "Equity"},
+])
+
+SERIES_B_TO_GROWTH_EQUITY = make_rows([
+    {"round_date_nzi": pd.Timestamp("2018-01-01"), "round_type_nzi": "Series B",      "financing_type_nzi": "Equity"},
+    {"round_date_nzi": pd.Timestamp("2020-01-01"), "round_type_nzi": "Growth equity", "financing_type_nzi": "Equity"},
+])
+
 
 # ---------------------------------------------------------------------------
 # Ensemble operating-status fixtures
@@ -274,6 +296,68 @@ class TestDidCompanySucceed:
     def test_shut_down_does_not_make_success(self):
         # Shut Down status alone doesn't make a company succeed
         assert did_company_succeed(SEED_ONLY_STALE, COMPANY_SHUT_DOWN) is False
+
+    def test_growth_equity_counts_as_graduation_past_series_a(self):
+        # Series A → Growth equity (no Series B+). "Growth equity" is a
+        # catch-all late-stage equity label outside DISCLOSED_STAGES_ORDERED,
+        # but it counts as graduation past Series A.
+        assert did_company_succeed(
+            SERIES_A_TO_GROWTH_EQUITY, COMPANY_OPERATING,
+            graduation_stages=("Series B",),
+        ) is True
+
+    def test_growth_equity_counts_as_graduation_past_seed(self):
+        # Seed → Growth equity (no Series A / Early VC). Growth equity is
+        # late-stage; raising it counts as graduation past Seed.
+        assert did_company_succeed(
+            SEED_TO_GROWTH_EQUITY, COMPANY_OPERATING,
+            graduation_stages=("Series A", "Early VC"),
+        ) is True
+
+    def test_growth_equity_counts_as_graduation_past_series_b(self):
+        # Series B → Growth equity (no Late VC / Series C+). Growth equity
+        # counts as graduation past Series B.
+        assert did_company_succeed(
+            SERIES_B_TO_GROWTH_EQUITY, COMPANY_OPERATING,
+            graduation_stages=("Late VC", "Series C"),
+        ) is True
+
+
+# ===========================================================================
+# _get_graduation_and_later_stages tests
+# ===========================================================================
+
+class TestGetGraduationAndLaterStages:
+    def test_series_b_graduation_includes_late_catch_alls(self):
+        # Series A's success threshold = ["Series B"]. The returned list
+        # should include Series B-and-later from DISCLOSED_STAGES_ORDERED
+        # PLUS the catch-all Late VC / Growth equity labels.
+        result = _get_graduation_and_later_stages(["Series B"], "Series B")
+        assert "Series B" in result
+        assert "Series C" in result
+        assert "Late VC" in result
+        assert "Growth equity" in result   # new
+
+    def test_series_a_graduation_includes_late_catch_alls(self):
+        # Seed's success threshold = ["Series A", "Early VC"]. Hits the
+        # second auto-append branch — returns Early VC + Growth equity.
+        result = _get_graduation_and_later_stages(["Series A", "Early VC"], "Series B")
+        assert "Series A" in result
+        assert "Series B" in result
+        assert "Early VC" in result
+        assert "Growth equity" in result   # new
+
+    def test_exit_graduation_still_includes_late_vc_and_growth_equity(self):
+        # Late_Exit's threshold = exit types. Late VC and Growth equity are
+        # still appended (the auto-append fires whenever graduation overlaps
+        # late_venture_stages). Note: this is a known over-inclusion for the
+        # Late_Exit cohort that flags as a separate cleanup.
+        result = _get_graduation_and_later_stages(
+            ["IPO", "Post IPO", "Post IPO - Equity", "SPAC"], "Series B",
+        )
+        assert "IPO" in result
+        assert "Late VC" in result
+        assert "Growth equity" in result
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- New `vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py` is the single source of truth for stage names, stage groupings, exit / M&A round-type sets, stage boundaries, split-strategy enums, the 2-year zombie cutoff, the survival-pipeline stages, and `STAGE_FAILURE_MAP`.
- Removed duplicate definitions in `split_early_late_funding_rounds.py`, `funding_round.py` (`ACQUISITION_ROUND_TYPES`), `nzi_zombie_companies_fail.py` (`STAGE_FAILURE_MAP`), and `nzi_survival_rates.py` (`_SEED_LEVEL_TYPES` → `SEED_COHORT_TYPES`, `_EARLY_VC_LEVEL_TYPES` → `A_TO_B_TYPES`, `NZI_SURVIVAL_STAGES`). All call sites now import from `stage_constants`.
- No behaviour change in the consolidation commit. Test pass/fail counts unchanged (81 passed, 33 pre-existing failures both before and after).

---

## Updates since the original PR (2026-05-25 → 2026-05-27)

Five follow-on commits landed on this branch after the original consolidation. The first two are scope extensions for `late_to_exit`; the next two are correctness fixes uncovered while validating the consolidated code against the Elemental dataset; the last one is documentation.

### 1. Expand per-period bucket gates to include `late_to_exit` (`497ae6e`)
`split_early_late_funding_rounds.py` was only emitting the per-investor-type and equity-split column sets for the three pre-B buckets (`up_to_a`, `a_to_b`, `b_to_late`). Extended the gates to also emit them for `late_to_exit`, so downstream callers can study late-stage investor mixes and funding-type breakdowns. `exit` is still excluded (the exit bucket is one-row-per-company, not a real funding period).

Tests for the previously-excluded `late_to_exit` columns updated to assert they're now present.

### 2. Rename per-period bucket-gating constants for clarity (`ed17235`)
The three bucket-gating sets in `split_early_late_funding_rounds.py` were named `EQUITY_SPLIT_BUCKETS`, `INVESTOR_COUNT_BUCKETS`, `INVESTOR_LIST_BUCKETS` — the names confused readers because the contents are *period names*, not bucket *contents*, and didn't match the `PERIOD_METRIC_COLS` convention used elsewhere. Renamed:

- `EQUITY_SPLIT_BUCKETS` → `PERIODS_WITH_FINANCING_TYPE_COLS`
- `INVESTOR_COUNT_BUCKETS` → `PERIODS_WITH_INVESTOR_TYPE_COUNTS`
- `INVESTOR_LIST_BUCKETS` → `PERIODS_WITH_INVESTOR_LIST`

Pure rename — no contents or semantics change.

### 3. Count "Growth equity" as graduation alongside Late VC (`13e90ad`)
`_get_graduation_and_later_stages` was treating "Growth equity" as invisible to the success predicate — it's not in `DISCLOSED_STAGES_ORDERED` and wasn't in either auto-append branch. A company that went `[Series A → Growth equity]` (no Series B+) was therefore classified as Series A failed (via the zombie / shut-down path) even though it had clearly graduated past Series A. Same bug for Pre-Seed / Seed / Series B success predicates.

Empirical context from 270 USA companies with Growth equity rounds (382 GE rounds total): 35% have no numbered Series at all; 46% of GE rounds are the first positional round in the company; 26% follow Series A or B (the impact set); 81% happen in companies that never reach Series C+. Growth equity is a late-stage equity *instrument* used across many funnel positions — when it follows a numbered Series, it functions as graduation past that series.

Fix: append "Growth equity" alongside the existing "Late VC" / "Early VC" catch-all auto-appends in both auto-append branches.

Per-stage impact on the Elemental USA dataset (analytic counts): Seed +21 succ, Series A +36, Series B +15, Late_Exit +92, Seed_Exit +72.

Tests: 3 new `did_company_succeed` cases (`[Series A → GE]`, `[Seed → GE]`, `[Series B → GE]`) + 3 new `_get_graduation_and_later_stages` unit tests. All 56 zombie-companies tests pass.

### 4. Suppress catch-all auto-append for exit cohorts (`7a6298e`)
While reviewing the Growth equity fix, found that `_get_graduation_and_later_stages` was also auto-appending Late VC + Growth equity to the graduation set of cohorts whose `graduation_stages` are exits — `Late_Exit` and `Seed_Exit`. Since Late VC / Growth equity are also in `Late_Exit`'s `at_stage_round_types`, the at-stage label was being treated as graduation: a company with `[Late VC, no exit]` was counted as Late_Exit succeeded even though it never exited. The numerator overlapped the cohort's entry condition.

Fix: when `graduation_stages` consists entirely of exit types (`set(g).issubset(EXIT_TYPES)`), suppress the catch-all auto-append. Real exits (IPO / SPAC / Post-IPO / M&A via the M&A path / ensemble status "Acquired / Merger") still graduate.

Per-stage rate impact on the Elemental USA dataset:
- **Late_Exit: 0.74 → 0.40** (−33.3 pp; 296 of 515 prior "successes" were artifacts)
- **Seed_Exit: 0.24 → 0.17** (−7.0 pp; 221 artifacts)
- Seed / Series A / Series B unaffected (suppression only fires for exit cohorts)

Reading: Late_Exit rate now correctly answers "of late-stage companies, what % actually exited?" — the analytical intent. Previously it answered "what % raised either an exit or a Late VC round", which was vacuously near-100% because every Late_Exit cohort member raised a late-stage round to enter the cohort.

Test updated (previously asserted the over-inclusion as a known issue) to assert the suppression. All 56 zombie-companies tests still pass.

### 5. Document `LATE_VC_CUTOFF` as a graduation-set trigger, not a taxonomy (`a628abd`)
The constant's name reads like a taxonomic definition ("where late venture begins?") but its only functional role is as a graduation-set inclusion threshold in `_get_graduation_and_later_stages`. With value `"Series B"`, a Series A cohort (graduation_stages = `["Series B"]`) sweeps in the Late VC / Growth equity catch-alls — that's correct, but it's inconsistent with the parallel `MIDDLE_STAGE_TYPES = {"Series B"}` which is taxonomic (Series B is *middle*, not late).

Both constants are correct for what they ask, but the naming overlap caused confusion in review. The fix is purely a docstring upgrade (no value change — changing it would have undone the Growth equity fix for Series A graduation). The docstring now explicitly contrasts with `MIDDLE_STAGE_TYPES` and explains the constant's role. Parameter docstring in `_get_graduation_and_later_stages` updated to match.

---

## Behavior changes summary

| Commit | Change | Affected cohorts | Numerical impact (Elemental USA) |
|---|---|---|---|
| `2e0dc23` | Consolidate constants | none | none |
| `497ae6e` | Emit per-investor / equity-split cols for `late_to_exit` | none (additive cols only) | none |
| `ed17235` | Rename bucket-gating sets | none | none |
| `13e90ad` | GE counts as graduation | Pre-Seed, Seed, Series A, Series B | +236 net succ across 5 cohorts |
| `7a6298e` | Suppress catch-all for exit cohorts | Late_Exit, Seed_Exit | Late_Exit −33.3 pp, Seed_Exit −7.0 pp |
| `a628abd` | Docs only | none | none |

## Test plan
- [x] All 56 zombie-companies tests pass (`pytest vdl_tools/scrape_enrich/netzero_insights/tests/test_nzi_zombie_companies.py`).
- [x] Funding-round-processing test failures are pre-existing (separate `divide_funding_rows` 4-vs-5 bucket return signature issue, unrelated to this PR).
- [ ] Downstream sibling PR `elemental-catalytic-capital#18` documents the corresponding rate-shift impact and bundles the elemental-side companion fixes (investor-presence period-gate, `min_companies` filter correction).