### PR TITLE
CB cache: normalize DateTime dtypes before merging DB and API frames

### DIFF
--- a/vdl_tools/scrape_enrich/crunchbase/organizations_api_db.py
+++ b/vdl_tools/scrape_enrich/crunchbase/organizations_api_db.py
@@ -55,6 +55,26 @@ def __rows_to_df(rows) -> pd.DataFrame | None:
     )
 
 
+def __coerce_to_model_schema(df: pd.DataFrame | None, model) -> pd.DataFrame | None:
+    """Normalize column dtypes to match the SQLAlchemy model.
+
+    DB-sourced frames (via __rows_to_df) get native Python types from
+    SQLAlchemy — DateTime columns come back as datetime objects. API-sourced
+    frames get raw JSON types — the same DateTime columns are ISO strings.
+    Concatenating the two yields an object column with mixed types that
+    PyArrow rejects at parquet write time. Coerce DateTime columns on each
+    side to pandas datetime64[ns, UTC] so the concat is type-safe.
+    """
+    if df is None or df.empty:
+        return df
+    for col in model.__table__.columns:
+        if col.name not in df.columns:
+            continue
+        if isinstance(col.type, sa.DateTime):
+            df[col.name] = pd.to_datetime(df[col.name], errors="coerce", utc=True)
+    return df
+
+
 def __dedup_df(df):
     if df is None or df.empty:
         return df
@@ -128,7 +148,7 @@ def __fetch_cached(session, model, ids, api_query_fn, *, use_cache, save_to_cach
             .filter(model.uuid.in_(ids))
             .all()
         )
-        cached_df = __rows_to_df(rows)
+        cached_df = __coerce_to_model_schema(__rows_to_df(rows), model)
 
     missing = ids
     if cached_df is not None and not cached_df.empty:
@@ -139,6 +159,7 @@ def __fetch_cached(session, model, ids, api_query_fn, *, use_cache, save_to_cach
         logger.info("Fetching %s missing %s from API...", len(missing), model.__tablename__)
         new_df = api_query_fn(missing)
         if new_df is not None and not new_df.empty:
+            new_df = __coerce_to_model_schema(new_df, model)
             cached_df = (
                 pd.concat([cached_df, new_df], ignore_index=True)
                 if cached_df is not None


### PR DESCRIPTION
## Summary

Fixes the root cause behind the `parquet_cache.write_dataframe` try/except hack in [#127](https://github.com/vibrant-data-labs/vdl-tools/pull/127) (see Lara's own [comment thread](https://github.com/vibrant-data-labs/vdl-tools/pull/127/files#r3346095580)).

`__fetch_cached` in `organizations_api_db.py` concatenates two frames whose dtypes diverge by construction:

- **DB side** — `__rows_to_df` pulls native Python types from SQLAlchemy, so `DateTime` columns come back as `datetime.datetime` objects (pandas → `datetime64[ns]`).
- **API side** — the iterative query path ends at [`pd.DataFrame.from_dict(results)`](https://github.com/vibrant-data-labs/vdl-tools/blob/main/vdl_tools/scrape_enrich/crunchbase/api.py#L128) over the raw Crunchbase JSON, so the same columns come back as ISO-8601 strings (and occasionally epoch ints).

After `pd.concat`, the column has `object` dtype with a `Timestamp`/`str`(/`int`) mix. `_scan_columns` in `parquet_cache.py` only samples the first 100 rows, so when one source dominates the head, the mix slips past and PyArrow blows up at write with `ArrowTypeError` — which is exactly the error Lara's hack catches and retries.

This PR normalizes the DateTime columns on **both** sides of the concat to `datetime64[ns, UTC]`, so the merge is type-safe and the resulting parquet has a well-defined `timestamp[ns, tz=UTC]` schema for those columns.

## Changes

- `vdl_tools/scrape_enrich/crunchbase/organizations_api_db.py`
  - Add `__coerce_to_model_schema(df, model)` — iterates `model.__table__.columns` and, for any `sa.DateTime` column present in `df`, runs `pd.to_datetime(df[col], errors="coerce", utc=True)`.
  - Call it in `__fetch_cached` on both `cached_df` (after `__rows_to_df`) and `new_df` (after the API call), before the `pd.concat`.

Deliberately narrow scope: only DateTime drift is being fixed because it is the only family with observed drift in the wild. Other type families (`String`, `Integer`, `Boolean`, `JSONB`) are left alone — broader coercion risks dtype changes that ripple into downstream code without evidence they are needed. The helper is trivial to extend if other drifts surface.

## Follow-up

Once this lands, the `try/except pa.lib.ArrowTypeError` block + regex column-name parsing in `parquet_cache.write_dataframe` (PR #127) should be reverted from that PR.

## Test plan

- [x] Synthetic repro: build a 120-row DB-shaped frame (Timestamps) + 50-row API-shaped frame (mix of ISO strings and epoch ints) and `pd.concat` them.
  - Pre-fix: `pa.Table.from_pandas(...)` raises `ArrowTypeError: object of type <class 'str'> cannot be converted to int ... Conversion failed for column created_at with type object` — same error the PR #127 hack catches.
  - Post-fix: both sides become `datetime64[ns, UTC]`, concat stays clean, PyArrow writes a `timestamp[ns, tz=UTC]` column.
- [ ] Real-data verification: run `query_companies_extended(some_ids, search_condition="id", use_cache=True, save_to_uri="/tmp/cb_fix_check")` with a list where ~half the orgs/people are already in the postgres cache and ~half are fresh. Confirm no late-detect warning fires and `pd.read_parquet(...)["created_at"].dtype == "datetime64[ns, UTC]"`.

Generated with [Claude Code](https://claude.com/claude-code)
