### PR TITLE
Scraper: fix scheme-sensitive link extraction + add per-host throttle

### DIFF
--- a/vdl_tools/scrape_enrich/scraper/async_scraper.py
+++ b/vdl_tools/scrape_enrich/scraper/async_scraper.py
@@ -1,8 +1,10 @@
 import asyncio
+import contextlib
 import logging
 import httpx
 from enum import Enum
 from typing import Optional, Dict, Any, List, Tuple
+from urllib.parse import urlparse
 from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError
 from playwright_stealth import Stealth
 
@@ -83,6 +85,7 @@ class AsyncScraper:
         retry_delay: float = DEFAULT_RETRY_DELAY,
         connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
         read_timeout: float = DEFAULT_READ_TIMEOUT,
+        max_per_host: Optional[int] = None,
     ):
         """
         Initialize the async scraper with separate concurrency limits for lightweight (HTTP)
@@ -96,6 +99,9 @@ class AsyncScraper:
             retry_delay: Base delay between retries (uses exponential backoff)
             connect_timeout: Timeout for establishing connection (fast fail on dead links)
             read_timeout: Timeout for reading response (allow time for slow servers)
+            max_per_host: Max concurrent HTTP requests to a single host. None disables
+                per-host throttling (default). Set to a small value (e.g. 3) to avoid
+                tripping rate limits (429s) when scraping many pages of one site.
         """
         self.http_sem = asyncio.Semaphore(max_concurrent_http)
         self.browser_sem = asyncio.Semaphore(max_concurrent_browser)
@@ -105,8 +111,25 @@ class AsyncScraper:
         self.retry_delay = retry_delay
         self.connect_timeout = connect_timeout
         self.read_timeout = read_timeout
+        self.max_per_host = max_per_host
+        self._host_sems: Dict[str, asyncio.Semaphore] = {}
         self.playwright = None
         self.browser = None
+
+    def _host_limiter(self, url: str):
+        """Return a context manager limiting concurrent requests to url's host.
+
+        When max_per_host is None this is a no-op. Per-host semaphores are created
+        lazily and cached; dict access is safe because asyncio is single-threaded.
+        """
+        if self.max_per_host is None:
+            return contextlib.nullcontext()
+        host = urlparse(url).netloc
+        sem = self._host_sems.get(host)
+        if sem is None:
+            sem = asyncio.Semaphore(self.max_per_host)
+            self._host_sems[host] = sem
+        return sem
 
     async def __aenter__(self):
         # Use separate timeouts: fast connect timeout to fail quickly on dead links,
@@ -168,10 +191,13 @@ class AsyncScraper:
             Tuple of (content, failure_reason, status_code).
             status_code is the actual HTTP status code, or 0 if the request never completed.
         """
-        async with self.http_sem:
-            if not url.startswith('http'):
-                url = f'https://{url}'
+        if not url.startswith('http'):
+            url = f'https://{url}'
 
+        # Per-host limiter is acquired OUTSIDE the global semaphore so that a single
+        # rate-limited host can't occupy the global HTTP pool while waiting on its own
+        # (smaller) slot, which would starve other hosts.
+        async with self._host_limiter(url), self.http_sem:
             for attempt in range(self.http_retries):
                 try:
                     response = await self.client.get(url)
@@ -358,6 +384,7 @@ async def scrape_urls_async(
     verify_ssl: bool = False,
     connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
     read_timeout: float = DEFAULT_READ_TIMEOUT,
+    max_per_host: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """
     Helper function to run the scraper for a list of URLs.
@@ -369,6 +396,7 @@ async def scrape_urls_async(
         verify_ssl: Whether to verify SSL certificates
         connect_timeout: Timeout for establishing connection (fast fail on dead links)
         read_timeout: Timeout for reading response (allow time for slow servers)
+        max_per_host: Max concurrent HTTP requests to a single host (None disables)
 
     Returns a list of results, one per URL. Failed URLs will have success=False.
     """
@@ -378,6 +406,7 @@ async def scrape_urls_async(
         verify_ssl=verify_ssl,
         connect_timeout=connect_timeout,
         read_timeout=read_timeout,
+        max_per_host=max_per_host,
     ) as scraper:
         tasks = [scraper.scrape_url(url) for url in urls]
         results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/vdl_tools/scrape_enrich/scraper/scrape_websites.py
+++ b/vdl_tools/scrape_enrich/scraper/scrape_websites.py
@@ -244,6 +244,7 @@ def scrape_websites_psql(
     return_combined_res: bool = True,
     verify_ssl: bool = True,
     max_per_subpath: int = 6,
+    max_per_host: int = 3,  # Cap concurrent requests per host to avoid 429s. None disables.
 ) -> pd.DataFrame:
 
     urls_ids = [(ensure_url_scheme(url), extract_website_name(url)) for url in urls]
@@ -339,7 +340,7 @@ def scrape_websites_psql(
             max_http = min(20, max_workers * 4)
             max_browser = min(3, max_workers)
 
-            async with AsyncScraper(max_http, max_browser, verify_ssl=verify_ssl) as scraper:
+            async with AsyncScraper(max_http, max_browser, verify_ssl=verify_ssl, max_per_host=max_per_host) as scraper:
                 for i, chunk in enumerate(chunks):
                     logger.info(f"Scraping chunk {i+1} / {len(chunks)}")
                     chunk_urls = [x[0] for x in chunk]

--- a/vdl_tools/scrape_enrich/scraper/website_processor.py
+++ b/vdl_tools/scrape_enrich/scraper/website_processor.py
@@ -167,15 +167,19 @@ def process_page_source(url: str, source: str):
 
 
 def filter_anchors(url, links):
+    # Compare prefixes without scheme so an http input still matches
+    # https hrefs in the page (and vice versa).
+    bare_url = url.split('://', 1)[1] if '://' in url else url
     urls = [
-        url.replace('www.', ''),
-        url[:-1] if url.endswith('/') else url,
+        bare_url.replace('www.', ''),
+        bare_url[:-1] if bare_url.endswith('/') else bare_url,
         '/'
     ]
 
     res_links = []
     for x in links:
-        matches = [s for s in urls if x.startswith(s) and len(x) > len(s)]
+        bare_x = x.split('://', 1)[1] if '://' in x else x
+        matches = [s for s in urls if bare_x.startswith(s) and len(bare_x) > len(s)]
         if len(matches) == 0:
             continue
 


### PR DESCRIPTION
## Problem

Scraping a site by its `http://` URL when the site serves over `https://` returned only the home page's relative links — most internal pages (about, news, etc.) were silently dropped.

Root cause: `filter_anchors` compared each anchor `href` against the input URL **with its scheme attached**. An `http://` input never `.startswith()`-matches an absolute `https://...` href, so those links were filtered out. Only purely relative `/path` links survived.

A secondary issue surfaced while testing: the internal-page burst fires every subpage concurrently, and small orgs' WAFs respond with `429 Too Many Requests`. Those 429s then cost exponential-backoff retries (1s/2s/4s) and could lose pages entirely.

## Changes

1. **Scheme-insensitive link extraction** (`website_processor.py`) — strip the scheme from both the base URL and each href before the prefix check. `http://` inputs now find `https://` links and vice versa. No behavior change for already-matching URLs; protocol-relative (`//...`) and external-link filtering is untouched.

2. **Per-host concurrency cap** (`async_scraper.py`) — new optional `max_per_host` on `AsyncScraper`. Lazily-created per-host `asyncio.Semaphore`, acquired **before** the global HTTP semaphore so a rate-limited host can't occupy global slots while waiting on its own (which would starve other hosts). Cross-host parallelism is preserved. `None` = disabled (unchanged behavior).

3. **Default `max_per_host=3`** in `scrape_websites_psql` — gentle 429 protection out of the box. In large batches the global limit of 20 is the binding constraint, so the per-host cap only meaningfully engages for the single-/few-site case (exactly the 429-prone scenario). Pass `None` to opt out.

## Verification

Before (reported by user): `http://www.aises.org` pulled no internal links beyond relative paths; with scheme fixed but no throttle, `/about` and `/news` came back blank with `429`.

After (all three changes): every real page returns `200` with text; only `/category` is non-200, and that's a genuine `404` (not a real page).

```
scrape_websites_psql(['http://www.aises.org'], return_combined_res=False, skip_existing=False, max_per_host=3)
# -> /, about, regions, impact, news, category/newsletter all 200; /category 404 (genuine)
```

Per-host limiter logic unit-checked in isolation: `max_per_host=None` → peak concurrency 12 (unthrottled); `max_per_host=3` across 2 hosts → peak 6 (3 per host), confirming cross-host parallelism is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)