### PR TITLE
Scraper: honor max_errors on the parse/combine layer (return_combined_res=True)

### DIFF
--- a/vdl_tools/scrape_enrich/scraper/scrape_websites.py
+++ b/vdl_tools/scrape_enrich/scraper/scrape_websites.py
@@ -109,6 +109,17 @@ def ensure_url_scheme(url: str) -> str:
     return url
 
 
+def _parsed_row_is_retryable(num_errors, max_errors):
+    """Whether a WebPagesParsed row is a prior combine failure that should be retried.
+
+    Retryable means it has between 1 and max_errors-1 errors (inclusive of 1). Successful
+    rows (0 errors) and rows that have hit the limit (>= max_errors) are NOT retryable:
+    the former are already done, the latter have been given up on. Mirrors the scrape-layer
+    retry condition used for urls_to_scrape so max_errors is honored on the parse layer too.
+    """
+    return 1 <= (num_errors or 0) < max_errors
+
+
 def process_website_text(url, data, add_section_links=False):
     return wp.get_page_text(url, data, add_section_links=add_section_links)
 
@@ -260,9 +271,15 @@ def scrape_websites_psql(
                 existing_parsed = session.query(WebPagesParsed).filter(
                     WebPagesParsed.cleaned_home_key.in_([x[1] for x in urls_ids])
                 ).all()
-                existing_parsed_data = [x.to_dict() for x in existing_parsed]
                 parsed_key_to_num_errors = {x.cleaned_home_key: (x.num_errors or 0) for x in existing_parsed}
                 existing_parsed_keys = parsed_key_to_num_errors
+                # Return previously-parsed rows as-is ONLY when we are not going to retry
+                # them. Retryable rows (1 <= num_errors < max_errors) are excluded here and
+                # re-combined below, so they are neither returned stale nor duplicated.
+                existing_parsed_data = [
+                    x.to_dict() for x in existing_parsed
+                    if not _parsed_row_is_retryable(x.num_errors, max_errors)
+                ]
             else:
                 existing_parsed_keys = {}
                 parsed_key_to_num_errors = {}
@@ -460,11 +477,16 @@ def scrape_websites_psql(
             scraped_df_for_combining = all_scraped_data_df.copy()
             scraped_df_for_combining['cleaned_home_key'] = scraped_df_for_combining['source'].apply(extract_website_name)
 
-            # Only combine data for websites that exist in WebPagesScraped but not in WebPagesParsed
+            # Combine data for websites that have scraped data and either have no parsed
+            # row yet OR have a prior parse failure still under the retry limit. The
+            # retryable clause mirrors the scrape-layer logic so max_errors is honored on
+            # the parse layer too (previously a single failure was permanent).
+            available_keys = set(scraped_df_for_combining['cleaned_home_key'].unique())
             unfound_index_rows = [
                 (url, website_id) for url, website_id in urls_to_process if
-                website_id not in existing_parsed_keys and
-                website_id in scraped_df_for_combining['cleaned_home_key'].unique()
+                website_id in available_keys and
+                (website_id not in existing_parsed_keys or
+                 _parsed_row_is_retryable(existing_parsed_keys[website_id], max_errors))
             ]
             unfound_chunks = list(chunked(unfound_index_rows, n_per_commit))
         else:

--- a/vdl_tools/scrape_enrich/scraper/tests/test_parse_retry.py
+++ b/vdl_tools/scrape_enrich/scraper/tests/test_parse_retry.py
@@ -1,0 +1,54 @@
+"""Tests for parse-layer (WebPagesParsed) retry gating.
+
+These pin down the predicate that decides whether a previously-parsed site is
+re-combined or returned as-is. The bug this guards against: a single combine
+failure (num_errors -> 1) used to be permanent because the combine step only ran
+for sites with NO parsed row at all, so the error counter could never climb to
+max_errors. The predicate below is the single source of truth shared by both the
+"return stale rows" filter and the "what to re-combine" filter.
+"""
+
+import pytest
+
+from vdl_tools.scrape_enrich.scraper.scrape_websites import (
+    _parsed_row_is_retryable,
+    MAX_ERRORS,
+)
+
+
+@pytest.mark.parametrize(
+    "num_errors,max_errors,expected",
+    [
+        # success: 0 (or None) errors -> done, never retry
+        (0, 5, False),
+        (None, 5, False),
+        # failures under the limit -> retry
+        (1, 5, True),
+        (4, 5, True),
+        # at or over the limit -> given up, return as-is
+        (5, 5, False),
+        (6, 5, False),
+        # boundary: with max_errors=1 even a single failure is already "given up"
+        (1, 1, False),
+        # boundary: with max_errors=2, one failure is retryable, two is not
+        (1, 2, True),
+        (2, 2, False),
+    ],
+)
+def test_parsed_row_is_retryable(num_errors, max_errors, expected):
+    assert _parsed_row_is_retryable(num_errors, max_errors) is expected
+
+
+def test_lifecycle_with_default_max_errors():
+    """Walk a site through its parse lifecycle under the default MAX_ERRORS.
+
+    A failing site should be retryable for counts 1..MAX_ERRORS-1, then drop out
+    of the retry set once it reaches MAX_ERRORS. This is what lets the error
+    counter actually accumulate to the limit instead of being pinned at 1.
+    """
+    # never parsed (count 0 / success) -> not retryable via this predicate
+    assert _parsed_row_is_retryable(0, MAX_ERRORS) is False
+    # every count strictly between 0 and MAX_ERRORS retries
+    assert all(_parsed_row_is_retryable(n, MAX_ERRORS) for n in range(1, MAX_ERRORS))
+    # at the limit, we give up
+    assert _parsed_row_is_retryable(MAX_ERRORS, MAX_ERRORS) is False


### PR DESCRIPTION
## Problem

When `scrape_websites_psql(..., return_combined_res=True)`, `max_errors` was **not** honored on the parse/combine layer.

A site whose combine step failed once got a `WebPagesParsed` row with `num_errors=1` and empty `combined_text`. On every later run (with the default `skip_existing=True`) it was returned **stale** from that row and **never retried** — even though `max_errors` (default 5) implies up to 5 attempts. A transient combine failure became permanent.

### Root cause

The combine step only selected sites with **no parsed row at all**:

```python
unfound_index_rows = [
    (url, website_id) for url, website_id in urls_to_process if
    website_id not in existing_parsed_keys and
    website_id in scraped_df_for_combining['cleaned_home_key'].unique()
]
```

Because a site only reached the error-counter write if it was *not* already in `parsed_key_to_num_errors`, the accumulator

```python
num_errors=parsed_key_to_num_errors.get(index_key, 0) + 1
```

always evaluated to `0 + 1 = 1`. The count could never climb to 2, 3, … so `max_errors > 1` had no effect on the parse layer. The scrape layer was unaffected — `urls_to_scrape` already retries `1 <= num_errors < max_errors`.

## Fix

A site is re-combined when it has scraped data **and** (has no parsed row **or** has a prior failure still under the limit), mirroring the scrape-layer condition:

```python
available_keys = set(scraped_df_for_combining['cleaned_home_key'].unique())
unfound_index_rows = [
    (url, website_id) for url, website_id in urls_to_process if
    website_id in available_keys and
    (website_id not in existing_parsed_keys or
     _parsed_row_is_retryable(existing_parsed_keys[website_id], max_errors))
]
```

Retryable rows are also excluded from the as-is return set (`existing_parsed_data`) so they are neither returned stale nor duplicated (they come back fresh via `combined_data`). This revives the previously-dead accumulator, so the counter now climbs 1 → 2 → … → `max_errors`, at which point the site drops out of `urls_to_process` and is returned as-is (given up).

A shared predicate `_parsed_row_is_retryable(num_errors, max_errors)` is the single source of truth for both filters, keeping them in sync.

### Lifecycle after the fix

| parsed state | re-combined? | returned as-is? |
|---|---|---|
| no row yet | ✅ (if scraped data exists) | — |
| success (0 errors) | ❌ | ✅ (cached result) |
| failure, `1 <= n < max_errors` | ✅ retry | ❌ |
| failure, `n >= max_errors` | ❌ given up | ✅ (stale, unchanged behavior) |

## Tests

`vdl_tools/scrape_enrich/scraper/tests/test_parse_retry.py` unit-tests the predicate across the full lifecycle (success / None / retryable range / at-limit / over-limit / `max_errors=1` and `=2` boundaries). 10 tests, all passing.

The DB-coupled selection logic around the predicate is not covered by an integration test here (would require a PSQL session + ProcessPool combine); the predicate carries the actual decision logic and the two call sites are thin wrappers over it.

## Scope / risk

- No change to the scrape layer or to `return_combined_res=False`.
- No change for sites that succeeded (still served from cache) or that already exceeded `max_errors` (still returned as-is).
- Behavior change is limited to sites with a parse failure under the limit: they now get retried, as `max_errors` always intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
