### PR TITLE
Fix: a_to_b period bucket must start at the first Series A / Early VC round

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -677,24 +677,30 @@ def _split_on_first_late_round(company_funding_rows, stages):
     # up_to_a window: rows before the first elevated row.
     up_to_a_end = first_elevated - 1 if first_elevated is not None else last_idx
 
-    # Only emit up_to_a if there's at least one Pre-Seed/Seed round in
-    # the range. Otherwise, leading non-equity rows (debt, convertible):
-    #   - are absorbed into a_to_b when a Series A round exists, matching
-    #     the old behavior where a convertible before Series A bundled
-    #     into the same bucket as the A.
-    #   - are dropped when no Series A exists either (e.g.
-    #     [Debt, Late VC, IPO]). Intentional: the old behavior
-    #     over-counted these outliers by bundling leading debt rounds
-    #     into the late_to_exit bucket, inflating late_to_exit totals by ~$1B across
-    #     the dataset.
-    has_up_to_a = up_to_a_end >= 0 and _has_stage_in_range(stages, "up_to_a", 0, up_to_a_end)
+    # Emit the up_to_a bucket when EITHER:
+    #   (a) there's a Pre-Seed/Seed round in the window (the original anchor), OR
+    #   (b) a Series A / Early VC round exists later — then by definition every
+    #       round before that first A is the "up to A" period, even pre-A grants /
+    #       accelerators / debt / convertibles that aren't Pre-Seed/Seed. This is
+    #       the fix (2026-06): without it, those leading pre-A rounds leaked into
+    #       the a_to_b bucket whenever the company had no Pre-Seed/Seed round, so
+    #       the a_to_b period didn't actually start at the first A. We anchor on
+    #       round POSITION (before the first A), not round TYPE, because grant /
+    #       accelerator / award rounds recur at every stage (39% of A companies
+    #       raise one AFTER their Series A) and so can't define the boundary.
+    #
+    # The no-Series-A case is unchanged: leading non-equity rows for a company
+    # like [Debt, Late VC, IPO] are still dropped (not bundled into late_to_exit),
+    # because first_a_to_b is None there and only the seed anchor (a) applies.
+    has_seed_anchor = up_to_a_end >= 0 and _has_stage_in_range(stages, "up_to_a", 0, up_to_a_end)
+    has_up_to_a = has_seed_anchor or (first_a_to_b is not None and up_to_a_end >= 0)
     up_to_a = _slice_or_none(company_funding_rows, 0, up_to_a_end) if has_up_to_a else None
 
-    # a_to_b: only exists if the company actually had an a_to_b stage round.
-    # When there's no up_to_a, leading non-equity rows get pulled into a_to_b
-    # so they're not silently dropped (matches old "early" semantics).
+    # a_to_b: only exists if the company actually had an a_to_b stage round, and it
+    # ALWAYS starts at that first Series A / Early VC round — the rounds before it
+    # are the up_to_a bucket (see above), never folded into a_to_b.
     if first_a_to_b is not None:
-        a_to_b_actual_start = first_a_to_b if has_up_to_a else 0
+        a_to_b_actual_start = first_a_to_b
         a_to_b_end = last_idx
         if b_to_late_start is not None:
             a_to_b_end = b_to_late_start - 1
@@ -771,6 +777,7 @@ def _split_after_last_early_round(company_funding_rows, stages):
     n = len(company_funding_rows)
     last_idx = n - 1
 
+    first_a_to_b = _find_first_index_at_stage(stages, "a_to_b")
     last_a_to_b = _find_last_index_at_stage(stages, "a_to_b")
     a_to_b_start_at_or_above = _find_first_index_at_or_above(stages, "a_to_b")
     late_to_exit_start = _find_first_index_at_or_above(stages, "late_to_exit")
@@ -786,12 +793,18 @@ def _split_after_last_early_round(company_funding_rows, stages):
     else:
         up_to_a_end = last_idx
 
-    has_up_to_a = up_to_a_end >= 0 and _has_stage_in_range(stages, "up_to_a", 0, up_to_a_end)
+    # Emit up_to_a on a Pre-Seed/Seed anchor OR (the 2026-06 fix) whenever a
+    # Series A / Early VC round exists later — everything before the first A is the
+    # up_to_a period by position, so pre-A grants / accelerators / debt no longer
+    # leak into a_to_b. See _split_on_first_late_round for the full rationale.
+    has_seed_anchor = up_to_a_end >= 0 and _has_stage_in_range(stages, "up_to_a", 0, up_to_a_end)
+    has_up_to_a = has_seed_anchor or (first_a_to_b is not None and up_to_a_end >= 0)
     up_to_a = _slice_or_none(company_funding_rows, 0, up_to_a_end) if has_up_to_a else None
 
-    # a_to_b: extends through last_a_to_b round (interleaved b_to_late stays in a_to_b).
+    # a_to_b: starts at the first Series A / Early VC round and extends through the
+    # last a_to_b round (interleaved b_to_late stays in a_to_b).
     if last_a_to_b is not None:
-        a_to_b_start = a_to_b_start_at_or_above if has_up_to_a else 0
+        a_to_b_start = first_a_to_b
         a_to_b = _slice_or_none(company_funding_rows, a_to_b_start, last_a_to_b)
         b_to_late_start = last_a_to_b + 1
     else:


### PR DESCRIPTION
## Background

Follow-on to #141 (the `first-a` PR, which split `a_to_b` equity into `a_to_b_first_a_raised` / `a_to_b_post_first_a_equity_raised`). While validating that split we noticed some companies whose **first round in the `a_to_b` period was not a Series A / Early VC** — which should be impossible by definition: the `a_to_b` funding period is, by construction, "from the first Series A / Early VC round up to the first Series B."

## The bug

`a_to_b` did **not** always start at the first Series A / Early VC round.

In `_split_on_first_late_round` (the production split strategy), the a_to_b start was:

```python
a_to_b_actual_start = first_a_to_b if has_up_to_a else 0
```

`has_up_to_a` was True only when a **Pre-Seed/Seed** round was present, because `UP_TO_A_TYPES = {Pre-Seed, Seed}` — which is **narrower than the seed cohort** `SEED_COHORT_TYPES = {Accelerator/incubator, Grant, Pre-Seed, Seed}`. So a company whose pre-A activity was *only* grants / accelerators / debt / convertibles (no Pre-Seed/Seed round) got **no `up_to_a` bucket**, and the `else 0` fallback folded those leading pre-A rounds into `a_to_b`. The a_to_b period therefore started at the wrong round, and its metrics were polluted with pre-A activity.

### Impact (USA data, 7,111 companies)

- **21.7% of all `a_to_b` buckets (550 companies)** had a first round that wasn't a Series A / Early VC.
- **1,682 pre-A rounds** (median 2/co, max 163) and **$1.6B** were mis-attributed to `a_to_b`.
- Leading round types: Grant (164), Accelerator/incubator (152), Debt (80), Spinoff/spinout (76), Convertible note (29), Award/Prize (21), crowdfunding, …

## Why not just broaden `UP_TO_A_TYPES`?

Because grant / accelerator / award rounds are **not** pre-A markers — they recur at every stage. Verified: **993 companies (39% of all A companies)** raise a grant/accelerator/award round *after* their first Series A (1,506 grants, 934 accelerators, 102 awards). Making them bucket-boundary types would mis-file post-A rounds. And it wouldn't even fully fix the problem: of the 547 affected, **276 (50%)** have ≥1 leading **non-seed** round (debt/convertible/spinoff/crowdfunding) that a type-based rule can't catch.

## The fix — anchor on position, not round type

In both split strategies (`_split_on_first_late_round`, `_split_after_last_early_round`): **whenever a Series A / Early VC round exists, every round before it is the `up_to_a` bucket and `a_to_b` starts exactly at that first A.**

```python
has_seed_anchor = up_to_a_end >= 0 and _has_stage_in_range(stages, "up_to_a", 0, up_to_a_end)
has_up_to_a = has_seed_anchor or (first_a_to_b is not None and up_to_a_end >= 0)
...
a_to_b_actual_start = first_a_to_b   # always start a_to_b at the first A / Early VC
```

The **no-Series-A case is deliberately unchanged**: a company like `[Debt, Late VC, IPO]` still drops its leading debt (it has no `first_a_to_b` anchor), preserving the behavior from #124 that stopped leading debt inflating `late_to_exit`.

## Verification (before → after, USA data)

| bucket | companies (old→new) | rounds (old→new) |
|---|---|---|
| `up_to_a` | 3,827 → **4,377** (+550) | 14,795 → **16,487** (+1,692) |
| `a_to_b` | 2,535 → 2,532 (−3) | 8,773 → **7,081** (−1,692) |
| `b_to_late` | 897 → 897 | 1,867 → 1,867 |
| `late_to_exit` | 860 → 860 | 3,086 → 3,086 |
| `exit` | 632 → 632 | 1,658 → 1,658 |

- **0** a_to_b buckets now start with a non-A round (was 550).
- The 1,692 rounds moved cleanly `a_to_b` → `up_to_a`; **perfect round conservation** (30,179 → 30,179), nothing dropped.
- **Dropped no-A leading rounds unchanged** (1,253 → 1,253).
- The −3 a_to_b companies are the cases that had *no real A round* and only got an a_to_b bucket via the old index-0 absorption — now correctly excluded.
- The #141 first-A split identities now hold **100%** (were 98.8%): `a_to_b_equity_raised == first_a_raised + post_first_a_equity_raised` and `a_to_b_n_rounds_equity == 1 + n_rounds_post_first_a_equity`.

### `b_to_late` / `late_to_exit` are NOT affected

This leakage was unique to `a_to_b` — only it had the index-0 fallback. The later buckets start via `_find_first_index_at_or_above`, which always lands exactly on the boundary round (pre-boundary debt/convertible/grant is absorbed into the *prior* bucket). Verified: every `b_to_late` bucket starts with Series B (897/897) and every `late_to_exit` bucket with a late-stage round (860/860).

### Cohort-level severity (what feeds the survival models)

Within the resolved success-v-fail cohorts: **A→B** stage (2,323 cos) — **18.1% (421)** affected, all by gaining a previously-missing `up_to_a` bucket; **Seed→A** stage (3,970 cos) — **11.8% (467)**. The **equity predictors are unaffected** (`a_to_b_first_a_raised` / `post_first_a_equity_raised` / `n_rounds_equity` changed in ~0 cos). What shifts is the non-equity side: `a_to_b_num_rounds` (median 5→2), `a_to_b_grant_raised`, `a_to_b_accelerator_raised`, `a_to_b_amount_raised` (~8%), the `a_to_b` investor-type counts, and the now-populated `up_to_a` period for the affected ~12–18%.

## Downstream

Pure upstream bucketing change — no downstream code change required. Consumers need a **data regen + model re-run** for the corrected `up_to_a_*` / `a_to_b_*` metrics to flow through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)