### PR TITLE
Add A_Exit and A_Late survival stages to STAGE_FAILURE_MAP

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -243,4 +243,12 @@ STAGE_FAILURE_MAP = {
         # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
         "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
     },
+    # Like Seed_Exit, but the cohort is the Series A stage (Series A ≡ Early VC) —
+    # "did a company that raised a Series A / Early VC round go on to an exit?".
+    "A_Exit": {
+        "at_stage_round_types": ["Series A", "Early VC"],
+        # M&A names are handled separately by `_has_successful_manda` and are
+        # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
+        "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
+    },
 }

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -251,4 +251,11 @@ STAGE_FAILURE_MAP = {
         # not in DISCLOSED_STAGES_ORDERED, so exclude them here.
         "graduation_stages": sorted(EXIT_TYPES - set(M_AND_A_NAMES)),
     },
+    # Series A cohort → reached a late-stage venture round (Late VC or Series C).
+    # Unlike A_Exit, graduation is late-venture (not exits), so the catch-all
+    # auto-append applies normally — same graduation set as Series B.
+    "A_Late": {
+        "at_stage_round_types": ["Series A", "Early VC"],
+        "graduation_stages": ["Late VC", "Series C"],
+    },
 }


### PR DESCRIPTION
Adds two synthetic survival stages whose cohort is the **Series A stage**
(`at_stage_round_types = ["Series A", "Early VC"]`, so both share the exact Series A
cohort — 3,160 USA companies, identical to the existing `Series A` cohort). They differ
only in the graduation bar:

- **`A_Exit`** — `graduation_stages = sorted(EXIT_TYPES − M_AND_A_NAMES)` (IPO/SPAC/Post-IPO;
  M&A handled by `_has_successful_manda`). Mirrors `Seed_Exit`/`Late_Exit`: graduation is
  exit-only, so the catch-all auto-append is suppressed and success requires an actual exit
  (IPO, or M&A at/after Series A) — not merely graduating to Series B. Verified
  `a_exit_succeeded ⊆ series_a_succeeded` (518 ⊆ 1,354 USA).
- **`A_Late`** — `graduation_stages = ["Late VC", "Series C"]` (same set as Series B). Graduation
  is late-venture (not exits), so the catch-all auto-append applies normally; success = the
  Series A cohort reached a late-stage round.

The classification flows through the existing generic `STAGE_FAILURE_MAP`-driven logic — no
changes to `did_company_succeed` / `did_company_fail` / `_precompute_company_classifications`.

USA survival rates order sensibly by how high the bar sits: Series A→B 0.58 > **A→Late 0.48**
> **A→Exit 0.28** > Seed→Exit 0.17.

Consumed downstream by `elemental_catalytic_capital/process_data.py` (`_STAGES` /
`_STAGE_COL_PREFIX`, prefixes `a_exit` / `a_late`), which materializes
`<prefix>_{succeeded,failed,unresolved,survived_failed}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)