### PR TITLE
Add Seed_Late survival stage to STAGE_FAILURE_MAP

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -258,4 +258,11 @@ STAGE_FAILURE_MAP = {
         "at_stage_round_types": ["Series A", "Early VC"],
         "graduation_stages": ["Late VC", "Series C"],
     },
+    # Seed cohort → reached a late-stage venture round (Late VC or Series C). Same
+    # seed cohort gate as Seed / Seed_Exit; like A_Late, graduation is late-venture
+    # (not exits), so the catch-all auto-append applies normally.
+    "Seed_Late": {
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
+        "graduation_stages": ["Late VC", "Series C"],
+    },
 }


### PR DESCRIPTION
Seed_Late shares the Seed cohort gate (at_stage_round_types = SEED_COHORT_TYPES,
same as Seed / Seed_Exit) but graduates on late-venture rounds
(graduation_stages = ["Late VC", "Series C"], same set as Series B / A_Late) —
"did a seed-cohort company reach a late-stage round?". Late-venture graduation
(not exit-only), so the catch-all auto-append applies normally.

Consumed downstream by elemental-catalytic-capital's Seed_Late stage
(process_data prefix seed_late) — already merged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)