### PR TITLE
NZI: b_to_late first-B equity split + Seed_B survival stage

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/split_early_late_funding_rounds.py
@@ -300,14 +300,19 @@ def divided_funding_rows_and_flatten(
         values among non-equity rounds). When the bucket exists,
         ``equity_raised + nonequity_raised == amount_raised`` (ignoring
         the NaN guard, which fires when every round of a given type in
-        the bucket was undisclosed). The **a_to_b bucket only** additionally
+        the bucket was undisclosed). The **a_to_b bucket** additionally
         gets ``a_to_b_first_a_raised`` (amount of the first Series A / Early VC
         round), ``a_to_b_post_first_a_equity_raised`` (sum of equity rounds after
         the first A — subsequent A bridges + any other equity before the first
         B), and ``a_to_b_n_rounds_post_first_a_equity`` (their count). These split
         ``a_to_b_equity_raised`` (= first_a + post, up to the undisclosed guard)
         and ``a_to_b_n_rounds_equity`` (= 1 + n_rounds_post_first_a_equity);
-        there is no ``n_rounds_first_a`` because it is always 1. When
+        there is no ``n_rounds_first_a`` because it is always 1. The **b_to_late
+        bucket** gets the analogous split around the first **Series B** round:
+        ``b_to_late_first_b_raised``, ``b_to_late_post_first_b_equity_raised``,
+        ``b_to_late_n_rounds_post_first_b_equity`` (the b_to_late bucket always
+        opens on the first Series B since the 2026-06 bucket-start fix, so the
+        identity holds cleanly). When
         ``processed_investor_df`` is provided, buckets in
         ``PERIODS_WITH_INVESTOR_LIST`` also get ``*_investors`` — a deduped
         list of ``{"id", "name", "investor_types"}`` dicts covering every
@@ -371,6 +376,13 @@ def divided_funding_rows_and_flatten(
                 round_group_dict["first_a_raised"] = None
                 round_group_dict["post_first_a_equity_raised"] = None
                 round_group_dict["n_rounds_post_first_a_equity"] = None
+            # B-to-LATE ONLY: the same split, but around the FIRST Series B round vs every
+            # equity round after it (subsequent B bridges + any equity before the first
+            # late-stage round). No ``n_rounds_first_b`` — the first B is a single round.
+            if round_name == "b_to_late":
+                round_group_dict["first_b_raised"] = None
+                round_group_dict["post_first_b_equity_raised"] = None
+                round_group_dict["n_rounds_post_first_b_equity"] = None
             if include_investor_lists and round_name in PERIODS_WITH_INVESTOR_LIST:
                 round_group_dict["investors"] = None
 
@@ -491,6 +503,36 @@ def divided_funding_rows_and_flatten(
                             post_sum = float("nan")
                         round_group_dict["n_rounds_post_first_a_equity"] = n_post
                         round_group_dict["post_first_a_equity_raised"] = post_sum
+
+                # B-to-LATE ONLY: same split around the first Series B round. The b_to_late
+                # bucket starts at the first Series-B-or-higher round and (since the 2026-06
+                # bucket-start fix) always opens on the first Series B, so the "first B" is the
+                # earliest round whose round_type is in MIDDLE_STAGE_TYPES (= {"Series B"}).
+                if round_name == "b_to_late":
+                    sorted_rounds = round_group_rounds.reset_index(drop=True)
+                    is_first_b_type = sorted_rounds['round_type_nzi'].isin(MIDDLE_STAGE_TYPES)
+                    b_positions = [i for i, is_b in enumerate(is_first_b_type) if is_b]
+                    if b_positions:
+                        first_b_pos = b_positions[0]
+                        # first_b_raised is a SINGLE round's amount — take it directly (NaN if
+                        # undisclosed; don't .sum(), which would turn that NaN into 0).
+                        round_group_dict["first_b_raised"] = float(
+                            sorted_rounds['round_amount_usd_nzi'].iloc[first_b_pos]
+                        )
+                        # Equity rounds strictly after the first B: subsequent B bridges and any
+                        # other equity rounds before the first late-stage round.
+                        after_first_b = sorted_rounds.iloc[first_b_pos + 1:]
+                        post_b_equity = after_first_b[
+                            after_first_b['financing_type_nzi'] == "Equity"
+                        ]
+                        n_post = int(len(post_b_equity))
+                        post_sum = float(post_b_equity['round_amount_usd_nzi'].sum())
+                        # Same undisclosed-amount guard as equity_raised: a 0 sum with >0 rounds
+                        # means every post-B equity round was undisclosed → NaN, not a true $0.
+                        if n_post > 0 and post_sum == 0:
+                            post_sum = float("nan")
+                        round_group_dict["n_rounds_post_first_b_equity"] = n_post
+                        round_group_dict["post_first_b_equity_raised"] = post_sum
             if include_investor_lists and round_name in PERIODS_WITH_INVESTOR_LIST:
                 round_group_dict["investors"] = _bucket_investors(
                     round_group_rounds, investor_lookup

--- a/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/process_nzi/stage_constants.py
@@ -265,4 +265,13 @@ STAGE_FAILURE_MAP = {
         "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
         "graduation_stages": ["Late VC", "Series C"],
     },
+    # Seed cohort → reached a Series B round. Same seed cohort gate as Seed /
+    # Seed_Exit / Seed_Late, but a lower bar than Seed_Late: graduation is Series B
+    # (same graduation set as the "Series A" cohort). The catch-all auto-append
+    # sweeps in everything at or after Series B, so a Seed company that jumped
+    # straight to Late VC / an exit still counts as having passed Series B.
+    "Seed_B": {
+        "at_stage_round_types": ["Accelerator/incubator", "Grant", "Pre-Seed", "Seed"],
+        "graduation_stages": ["Series B"],
+    },
 }


### PR DESCRIPTION
Two NZI `process_nzi` additions that back downstream survival-modeling work in elemental-catalytic-capital.

## Changes
1. **`split_early_late_funding_rounds`** — split the `b_to_late` bucket's equity into **first-B** vs **post-first-B** (mirrors the existing `a_to_b` first-A split): emits `first_b_raised`, `post_first_b_equity_raised`, `n_rounds_post_first_b_equity`. Undisclosed → NaN guard. Identities verified 100% on USA data ($ and round counts).
2. **`stage_constants.STAGE_FAILURE_MAP`** — new **`Seed_B`** stage: Seed cohort → reached Series B. Same seed-cohort gate as Seed/Seed_Exit/Seed_Late, graduating on `["Series B"]` (catch-all auto-append sweeps in everything at/after B).

## Why
- The first-B split feeds the `b_to_late` model period's equity features (paired with a `USE_FIRST_ROUND_EQUITY_SPLIT` toggle downstream).
- `Seed_B` materializes the `seed_b_*` survival columns that the elemental **seed_to_b** model stage and the Seed→B survival-rate / amount-raised figures consume.

## Companion PR
Paired with the elemental-catalytic-capital `funnel-steps → main` PR, which depends on both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)