### PR TITLE
Postgres-backed geocode cache (v2)

### DIFF
--- a/vdl_tools/scrape_enrich/geocode_cache_backfill.py
+++ b/vdl_tools/scrape_enrich/geocode_cache_backfill.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""One-time backfill: S3 geocode cache -> Postgres `geocode` table.
+
+Loads the existing S3 cache (bucket `geocode-cache`) into the new Postgres table so
+already-geocoded addresses are not re-billed to Google after switching to v2.
+
+S3 key layout written by the v1 cache (`geocode_cache.GeocodeCache`):
+  - `<address>.json`         -> successful result (JSON body: latitude/longitude/
+                                city/state/country/raw)
+  - `errors/<address>.json`  -> failed lookup (empty body)
+  - `hashed_<uuid>.json`     -> result for an address >100 chars; the original
+                                address is NOT recoverable from the key, so it
+                                cannot be re-keyed to match future lookups -> SKIPPED
+                                (logged). Those few re-geocode on next encounter.
+
+Errors are upserted first, then successes, so an address that has both an old error
+marker and a later successful result ends up successful (num_errors cleared).
+
+Run:
+    python -m vdl_tools.scrape_enrich.geocode_cache_backfill --limit 500   # dry-ish test
+    python -m vdl_tools.scrape_enrich.geocode_cache_backfill               # full backfill
+"""
+import argparse
+import json
+from multiprocessing.pool import ThreadPool
+
+import boto3
+from more_itertools import chunked
+
+import vdl_tools.shared_tools.tools.config_utils as config_tools
+from vdl_tools.scrape_enrich.geocode_cache import (
+    S3_DEFAULT_BUCKET_NAME,
+    S3_DEFAULT_BUCKET_REGION,
+)
+from vdl_tools.scrape_enrich.geocode_cache_sql import GeocodeCache, DEFAULT_PROVIDER
+from vdl_tools.shared_tools.database_cache.database_utils import get_session
+from vdl_tools.shared_tools.tools.logger import logger
+
+_JSON_SUFFIX = ".json"
+_ERROR_PREFIX = "errors/"
+
+
+def _build_s3_client(config=None):
+    """Boto3 S3 client + bucket name, resolved the same way as v1 GeocodeCache."""
+    config = config or config_tools.get_configuration()
+    bucket = config_tools.get_configuration_value(
+        config, 'aws.geocode_cache_bucket', S3_DEFAULT_BUCKET_NAME)
+    region = config_tools.get_configuration_value(
+        config, 'aws.region', S3_DEFAULT_BUCKET_REGION)
+    client = boto3.client(
+        "s3",
+        aws_access_key_id=config_tools.get_configuration_value(config, 'aws.access_key_id'),
+        aws_secret_access_key=config_tools.get_configuration_value(config, 'aws.secret_access_key'),
+        region_name=region,
+    )
+    return client, bucket
+
+
+def _list_all_keys(client, bucket, prefix=None, limit=None):
+    paginator = client.get_paginator('list_objects_v2')
+    kwargs = {'Bucket': bucket}
+    if prefix:
+        kwargs['Prefix'] = prefix
+    keys = []
+    for page in paginator.paginate(**kwargs):
+        keys.extend(obj['Key'] for obj in page.get('Contents', []))
+        if limit and len(keys) >= limit:  # stop early for --limit test runs
+            break
+    return keys
+
+
+def _get_body(client, bucket, key):
+    obj = client.get_object(Bucket=bucket, Key=key)
+    return obj['Body'].read().decode('utf-8')
+
+
+def backfill(
+    config=None,
+    prefix=None,
+    limit=None,
+    n_per_commit=1000,
+    max_workers=20,
+    provider=DEFAULT_PROVIDER,
+):
+    config = config or config_tools.get_configuration()
+    client, bucket = _build_s3_client(config)
+
+    logger.info("Listing objects in s3 bucket '%s'%s", bucket, f" (prefix={prefix})" if prefix else "")
+    keys = _list_all_keys(client, bucket, prefix=prefix, limit=limit)
+    if limit:
+        keys = keys[:limit]
+    logger.info("Found %s objects", len(keys))
+
+    # classify keys
+    success_keys: list[str] = []
+    error_addresses: list[str] = []
+    skipped_hashed = 0
+    for key in keys:
+        if not key.endswith(_JSON_SUFFIX):
+            continue
+        if key.startswith(_ERROR_PREFIX):
+            addr = key[len(_ERROR_PREFIX):-len(_JSON_SUFFIX)]
+            if addr.startswith("hashed_"):
+                skipped_hashed += 1
+                continue
+            error_addresses.append(addr)
+        else:
+            stem = key[:-len(_JSON_SUFFIX)]
+            if stem.startswith("hashed_"):
+                skipped_hashed += 1
+                continue
+            success_keys.append(key)
+
+    logger.info(
+        "%s success objects, %s error markers, %s hashed (skipped)",
+        len(success_keys), len(error_addresses), skipped_hashed,
+    )
+
+    # The cache class needs Google creds to build its geolocator, but the backfill
+    # never geocodes — pass empty creds (no network call happens at construction).
+    with get_session() as session:
+        cache = GeocodeCache(session, user="backfill", key="backfill", provider=provider)
+
+        # Errors first so a later successful result wins (clears num_errors).
+        n_errors = 0
+        for chunk in chunked(error_addresses, n_per_commit):
+            rows = [cache._build_error_row(addr) for addr in chunk]
+            cache._upsert_error_rows(rows)
+            session.commit()
+            n_errors += len(rows)
+            logger.info("Upserted %s/%s error rows", n_errors, len(error_addresses))
+
+        # Successes: fetch bodies in parallel, parse, bulk upsert per chunk.
+        def _fetch_and_build(key):
+            try:
+                body = _get_body(client, bucket, key)
+                data = json.loads(body)
+            except Exception as ex:  # noqa: BLE001 - skip unreadable/garbage objects
+                logger.warning("Skipping unreadable object %s: %s", key, ex)
+                return None
+            address = key[:-len(_JSON_SUFFIX)]
+            # stored location_data already has latitude/longitude/city/state/country/raw
+            return cache._build_success_row(address, data)
+
+        n_success = 0
+        with ThreadPool(processes=max_workers) as pool:
+            for chunk in chunked(success_keys, n_per_commit):
+                rows = [r for r in pool.map(_fetch_and_build, chunk) if r]
+                cache._upsert_success_rows(rows)
+                session.commit()
+                n_success += len(rows)
+                logger.info("Upserted %s/%s success rows", n_success, len(success_keys))
+
+    logger.info(
+        "Backfill complete: %s success, %s errors, %s hashed skipped",
+        n_success, n_errors, skipped_hashed,
+    )
+    return {"success": n_success, "errors": n_errors, "skipped_hashed": skipped_hashed}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill S3 geocode cache into Postgres.")
+    parser.add_argument("--prefix", default=None, help="Only backfill keys under this S3 prefix.")
+    parser.add_argument("--limit", type=int, default=None, help="Only process the first N keys (test runs).")
+    parser.add_argument("--n-per-commit", type=int, default=1000, help="Rows per bulk upsert/commit.")
+    parser.add_argument("--max-workers", type=int, default=20, help="Parallel S3 GET workers.")
+    args = parser.parse_args()
+    backfill(
+        prefix=args.prefix,
+        limit=args.limit,
+        n_per_commit=args.n_per_commit,
+        max_workers=args.max_workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/vdl_tools/scrape_enrich/geocode_cache_sql.py
+++ b/vdl_tools/scrape_enrich/geocode_cache_sql.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+"""Postgres-backed geocode cache.
+
+Mirrors `vdl_tools.shared_tools.openai.embedding_cache.EmbeddingCache`: one bulk
+SQL read for all addresses up front, geocode only the misses, then chunked bulk
+upserts (`INSERT ... ON CONFLICT DO UPDATE`). Replaces the one-object-at-a-time
+S3/filesystem cache in `geocode_cache.py`.
+
+Like `EmbeddingCache` owns the OpenAI call, this class owns the Google geocoder.
+Google geocodes one address per request (and is rate-limited), so the "run the
+misses" step is a sequential rate-limited loop; the speedup is on the cache I/O.
+"""
+import datetime as dt
+from typing import Any
+
+from geopy.geocoders import GoogleV3
+from geopy.extra.rate_limiter import RateLimiter
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from vdl_tools.scrape_enrich.geocode_cache import get_component
+from vdl_tools.shared_tools.database_cache.database_models.geocode import Geocode
+from vdl_tools.shared_tools.tools.logger import logger
+
+
+DEFAULT_PROVIDER = 'google'
+
+
+class GeocodeCache:
+    """SQL-backed cache + Google geocoder for forward geocoding."""
+
+    def __init__(
+        self,
+        session: Session,
+        user: str,
+        key: str,
+        provider: str = DEFAULT_PROVIDER,
+        min_delay_seconds: float = 1 / 50,
+    ):
+        self.session = session
+        self.provider = provider
+        self.geolocator = GoogleV3(user_agent=user, api_key=key)
+        # auto rate limiter (same cadence as geocode.py v1)
+        self.geocode_rate_limited = RateLimiter(
+            self.geolocator.geocode, min_delay_seconds=min_delay_seconds
+        )
+
+    def geocode_one(self, address: str):
+        """Single rate-limited Google geocode call.
+
+        Returns a location dict (latitude, longitude, city, state, country, raw)
+        on a hit, or None when Google returns no result.
+        """
+        data = self.geocode_rate_limited(address)
+        if not data:
+            return None
+        return {
+            'latitude': data.latitude,
+            'longitude': data.longitude,
+            'city': get_component(data, "locality"),
+            'state': get_component(data, "administrative_area_level_1"),
+            'country': get_component(data, "country"),
+            'raw': data.raw,
+        }
+
+    def get_geocode_obj(self, address: str):
+        address_id = Geocode.create_address_id(address)
+        return (
+            self.session
+            .query(Geocode)
+            .filter(
+                Geocode.provider == self.provider,
+                Geocode.address_id == address_id,
+            )
+            .first()
+        )
+
+    def get_geocode_obj_bulk(self, addresses: list[str]):
+        """Bulk-read cached rows for many addresses.
+
+        Returns (found_rows, unfound_ids_or_errors):
+          - found_rows: successful (non-errored) Geocode rows present in the DB
+          - unfound_ids_or_errors: {address_id -> num_errors} for address_ids that
+            are absent (0) or present-but-errored (>0)
+        """
+        logger.info(
+            "Starting to pull %s previous results for provider: %s",
+            len(addresses),
+            self.provider,
+        )
+        address_ids = [Geocode.create_address_id(a) for a in addresses]
+        all_rows = (
+            self.session
+            .query(Geocode)
+            .filter(
+                Geocode.provider == self.provider,
+                Geocode.address_id.in_(address_ids),
+            )
+            .all()
+        )
+
+        found_rows_to_errors = {x.address_id: x.num_errors for x in all_rows}
+        found_rows = [x for x in all_rows if not found_rows_to_errors.get(x.address_id)]
+
+        found_rows_keys = found_rows_to_errors.keys()
+        unfound_ids_or_errors = {
+            x: found_rows_to_errors.get(x, 0) for x in address_ids
+            if x not in found_rows_keys or found_rows_to_errors.get(x)
+        }
+        logger.info("%s previous found, %s unfound", len(found_rows), len(unfound_ids_or_errors))
+        return found_rows, unfound_ids_or_errors
+
+    def _build_success_row(self, address: str, location: dict) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "address_id": Geocode.create_address_id(address),
+            "address": address,
+            "latitude": location.get("latitude"),
+            "longitude": location.get("longitude"),
+            "city": location.get("city"),
+            "state": location.get("state"),
+            "country": location.get("country"),
+            "response_full": location.get("raw"),
+            "num_errors": None,
+        }
+
+    def _build_error_row(self, address: str, response_full: dict = None) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "address_id": Geocode.create_address_id(address),
+            "address": address,
+            "latitude": None,
+            "longitude": None,
+            "city": None,
+            "state": None,
+            "country": None,
+            "response_full": response_full or {"message": "No geocode result"},
+            "num_errors": 1,
+        }
+
+    def _upsert_success_rows(self, rows: list[dict[str, Any]]):
+        """Bulk upsert successful rows via PG ON CONFLICT.
+
+        Composite PK is (provider, address_id). On conflict, overwrites the
+        location fields, clears num_errors, and bumps date_updated (Core doesn't
+        fire the ORM `onupdate` hook through `ON CONFLICT DO UPDATE`).
+        """
+        if not rows:
+            return
+        deduped: dict[tuple, dict[str, Any]] = {}
+        for row in rows:
+            deduped[(row["provider"], row["address_id"])] = row
+        rows = list(deduped.values())
+
+        # Columns are naive `DateTime` (BaseMixin); strip tz to keep round-trip identical.
+        now = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+        for row in rows:
+            row.setdefault("date_added", now)
+            row.setdefault("date_updated", now)
+
+        stmt = pg_insert(Geocode).values(rows)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["provider", "address_id"],
+            set_={
+                "address": stmt.excluded.address,
+                "latitude": stmt.excluded.latitude,
+                "longitude": stmt.excluded.longitude,
+                "city": stmt.excluded.city,
+                "state": stmt.excluded.state,
+                "country": stmt.excluded.country,
+                "response_full": stmt.excluded.response_full,
+                "num_errors": None,
+                # date_added intentionally NOT in the SET clause — preserve the
+                # original "first cached at" timestamp on refresh.
+                "date_updated": now,
+            },
+        )
+        self.session.execute(stmt)
+
+    def _upsert_error_rows(self, rows: list[dict[str, Any]]):
+        """Bulk upsert error rows, incrementing num_errors on conflict."""
+        if not rows:
+            return
+        deduped: dict[tuple, dict[str, Any]] = {}
+        for row in rows:
+            deduped[(row["provider"], row["address_id"])] = row
+        rows = list(deduped.values())
+
+        now = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+        for row in rows:
+            row.setdefault("date_added", now)
+            row.setdefault("date_updated", now)
+
+        stmt = pg_insert(Geocode).values(rows)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["provider", "address_id"],
+            set_={
+                "response_full": stmt.excluded.response_full,
+                "num_errors": func.coalesce(Geocode.num_errors, 0) + 1,
+                "date_updated": now,
+            },
+        )
+        self.session.execute(stmt)
+
+    @staticmethod
+    def _row_to_location(row) -> dict:
+        """Map a Geocode row (or success-row dict) to the pipeline location dict."""
+        getter = row.get if isinstance(row, dict) else lambda k: getattr(row, k)
+        return {
+            "latitude": getter("latitude"),
+            "longitude": getter("longitude"),
+            "city": getter("city"),
+            "state": getter("state"),
+            "country": getter("country"),
+        }
+
+    def bulk_get_cache_or_run(
+        self,
+        addresses: list[str],
+        use_cached_result: bool = True,
+        n_per_commit: int = 500,
+        max_errors: int = 1,
+    ) -> dict[str, dict]:
+        """Bulk lookup/geocode.
+
+        For each (normalized) address, return the cached location or geocode it and
+        store the result. Addresses already cached with >= max_errors are treated as
+        permanent failures and are NOT re-geocoded (default max_errors=1 means a
+        single recorded failure is respected — fixes v1 re-paying Google every run).
+
+        Returns: {address -> {latitude, longitude, city, state, country}}
+        """
+        # dedupe (preserve order) and drop empties
+        unique_addresses = list(dict.fromkeys(a for a in addresses if a))
+        if not unique_addresses:
+            return {}
+
+        if use_cached_result:
+            found_rows, unfound_ids_errors = self.get_geocode_obj_bulk(unique_addresses)
+            unfound_addresses = []
+            for address in unique_addresses:
+                address_id = Geocode.create_address_id(address)
+                errors_for_id = unfound_ids_errors.get(address_id, 0)
+                if (
+                    address_id in unfound_ids_errors and
+                    (errors_for_id == 0 or errors_for_id < max_errors)
+                ):
+                    unfound_addresses.append(address)
+        else:
+            unfound_addresses = unique_addresses
+            found_rows = []
+
+        res = {x.address: self._row_to_location(x) for x in found_rows}
+
+        len_unfound = len(unfound_addresses)
+        logger.info("Found %s cached geocodes", len(res))
+        logger.info("Need to geocode %s addresses", len_unfound)
+
+        if not unfound_addresses:
+            return res
+
+        success_rows: list[dict[str, Any]] = []
+        error_rows: list[dict[str, Any]] = []
+        n_run = 0
+        try:
+            for address in unfound_addresses:
+                location = self.geocode_one(address)
+                if location:
+                    row = self._build_success_row(address, location)
+                    success_rows.append(row)
+                    res[address] = self._row_to_location(row)
+                else:
+                    error_rows.append(self._build_error_row(address))
+                n_run += 1
+
+                if n_run % n_per_commit == 0:
+                    self._upsert_success_rows(success_rows)
+                    self._upsert_error_rows(error_rows)
+                    self.session.commit()
+                    logger.info("Committed %s of %s geocodes", n_run, len_unfound)
+                    success_rows, error_rows = [], []
+        except KeyboardInterrupt:
+            logger.warning(
+                "(Geocode) Received KeyboardInterrupt, committing partial progress..."
+            )
+
+        # flush remainder
+        self._upsert_success_rows(success_rows)
+        self._upsert_error_rows(error_rows)
+        self.session.commit()
+        logger.info("Total geocodes in result: %s", len(res))
+        return res

--- a/vdl_tools/scrape_enrich/geocode_v2.py
+++ b/vdl_tools/scrape_enrich/geocode_v2.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Geocoding v2 — Postgres-backed cache.
+
+Drop-in replacement for `geocode.py` with an identical public API
+(`geocode_addresses`, `get_lat_long`, `add_geo_lat_long`) and output columns, but
+backed by the Postgres `geocode` table instead of the S3 + local-file cache.
+
+Instead of one S3 GET/PUT per address, it issues a single bulk SQL read for every
+address up front, geocodes only the misses (rate-limited Google calls), and bulk
+upserts the results. See `geocode_cache_sql.GeocodeCache`.
+
+Cache-independent helpers (`clean_geo`, `reverse_geocode_addresses`, `get_component`,
+`geo_rename_dict`, `get_api_info`) are unchanged from v1 and re-exported here so
+callers only need to import from `geocode_v2`.
+"""
+from vdl_tools.scrape_enrich.geocode import (
+    geo_rename_dict,
+    get_api_info,
+    clean_geo,
+    reverse_geocode_addresses,
+)
+from vdl_tools.scrape_enrich.geocode_cache import get_component
+from vdl_tools.scrape_enrich.geocode_cache_sql import GeocodeCache
+from vdl_tools.shared_tools.database_cache.database_utils import get_session
+
+__all__ = [
+    "geocode_addresses",
+    "get_lat_long",
+    "add_geo_lat_long",
+    "clean_geo",
+    "reverse_geocode_addresses",
+    "get_component",
+    "geo_rename_dict",
+    "get_api_info",
+]
+
+
+def geocode_addresses(df, address, test=None, use_cached_result=True):
+    """
+    get lat long from address
+    also extract city, state, and country
+    df : dataframe with address
+    address : column name of address
+    test : sample size for testing
+
+    Returns: df with added columns of latitude, longitude, city, state, country
+    """
+    if test is not None:
+        print("subset %d for testing" % test)
+        df = df.head(test).copy()
+    # only compute on facilities that have address info
+    df = df.reset_index(drop=True)
+    df[address] = df[address].fillna("")
+    for string1, string2 in geo_rename_dict.items():  # spell corrections for geocoding
+        df.loc[:, address] = df[address].str.replace(string1, string2)
+    # remove records with no address
+    df_w_geo = df[df[address].apply(lambda x: x != "")]
+    df_w_geo = df_w_geo.reset_index(drop=True)  # trying to avoid slice error...
+
+    # Bulk: read the cache for every address at once, then geocode only the misses.
+    USER, KEY = get_api_info()
+    unique_addresses = df_w_geo[address].unique().tolist()
+    print("getting lat/longs with postgres geocode cache")
+    with get_session() as session:
+        cache = GeocodeCache(session, USER, KEY)
+        address_to_location = cache.bulk_get_cache_or_run(
+            unique_addresses,
+            use_cached_result=use_cached_result,
+        )
+
+    # `.get` -> None for addresses that errored / returned no result (NaN-safe)
+    df_w_geo['location'] = df_w_geo[address].apply(lambda a: address_to_location.get(a))
+
+    print("getting address components")
+    df_w_geo["Latitude"] = df_w_geo["location"].apply(
+        lambda x: x['latitude'] if x else ""
+    )
+    df_w_geo["Longitude"] = df_w_geo["location"].apply(
+        lambda x: x['longitude'] if x else ""
+    )
+
+    df_w_geo["city"] = df_w_geo["location"].apply(
+        lambda x: x['city'] if x else None
+    )
+    df_w_geo["state"] = df_w_geo["location"].apply(
+        lambda x: x['state'] if x else None
+    )
+    df_w_geo["country"] = df_w_geo["location"].apply(
+        lambda x: x['country'] if x else None
+    )
+
+    df_w_geo.drop("location", axis=1, inplace=True)
+    return df_w_geo
+
+
+def get_lat_long(
+    df,
+    idCol,
+    address,
+    use_cached_result=True
+):
+    """
+    Get lat lon.
+
+    # parse location from linkedIn top card
+    # idCol: column to use for merging
+    """
+    df["Address"] = df[address]
+    # get lat long and city, state, country from final addresses
+    print("geocoding addresses")
+    df_geo = df[[idCol, "Address"]]
+    df_geo = geocode_addresses(df_geo, "Address",
+                               use_cached_result=use_cached_result)
+    df.drop(["Address"], axis=1, inplace=True)  # remove origional address for merging
+    return df_geo
+
+
+def add_geo_lat_long(
+    df,
+    idCol="id",  # unique id column
+    address="Location",  # column with address
+    use_cached_result=True
+):
+    """
+    Add geo lat lon to a dataframe with an address column
+
+    add lat/long, hq city, state, country from address to recipient metadata
+    df :  metadata file, must have [idCol, address] columns
+    idCol : unique id for merging metadata
+    """
+    print("\nAdding Lat/Long, City, Region, Country")
+    df_geo = get_lat_long(
+        df,
+        idCol,
+        address,
+        use_cached_result=use_cached_result
+    )
+
+    # merge geo data to main file
+    if address == "Address":
+        df.drop(["Address"], axis=1, inplace=True)  # drop for merging with new
+    df_w_geo = df.merge(df_geo, on=idCol, how="left")
+    return df_w_geo

--- a/vdl_tools/scrape_enrich/geocode_v2.py
+++ b/vdl_tools/scrape_enrich/geocode_v2.py
@@ -23,6 +23,8 @@ from vdl_tools.scrape_enrich.geocode import (
 from vdl_tools.scrape_enrich.geocode_cache import get_component
 from vdl_tools.scrape_enrich.geocode_cache_sql import GeocodeCache
 from vdl_tools.shared_tools.database_cache.database_utils import get_session
+from vdl_tools.shared_tools.tools.logger import logger
+
 
 __all__ = [
     "geocode_addresses",
@@ -47,7 +49,7 @@ def geocode_addresses(df, address, test=None, use_cached_result=True):
     Returns: df with added columns of latitude, longitude, city, state, country
     """
     if test is not None:
-        print("subset %d for testing" % test)
+        logger.info("subset %d for testing" % test)
         df = df.head(test).copy()
     # only compute on facilities that have address info
     df = df.reset_index(drop=True)
@@ -61,7 +63,7 @@ def geocode_addresses(df, address, test=None, use_cached_result=True):
     # Bulk: read the cache for every address at once, then geocode only the misses.
     USER, KEY = get_api_info()
     unique_addresses = df_w_geo[address].unique().tolist()
-    print("getting lat/longs with postgres geocode cache")
+    logger.info("getting lat/longs with postgres geocode cache")
     with get_session() as session:
         cache = GeocodeCache(session, USER, KEY)
         address_to_location = cache.bulk_get_cache_or_run(
@@ -72,7 +74,7 @@ def geocode_addresses(df, address, test=None, use_cached_result=True):
     # `.get` -> None for addresses that errored / returned no result (NaN-safe)
     df_w_geo['location'] = df_w_geo[address].apply(lambda a: address_to_location.get(a))
 
-    print("getting address components")
+    logger.info("getting address components")
     df_w_geo["Latitude"] = df_w_geo["location"].apply(
         lambda x: x['latitude'] if x else ""
     )
@@ -108,10 +110,13 @@ def get_lat_long(
     """
     df["Address"] = df[address]
     # get lat long and city, state, country from final addresses
-    print("geocoding addresses")
+    logger.info("geocoding addresses")
     df_geo = df[[idCol, "Address"]]
-    df_geo = geocode_addresses(df_geo, "Address",
-                               use_cached_result=use_cached_result)
+    df_geo = geocode_addresses(
+        df_geo,
+        "Address",
+        use_cached_result=use_cached_result,
+    )
     df.drop(["Address"], axis=1, inplace=True)  # remove origional address for merging
     return df_geo
 
@@ -129,12 +134,12 @@ def add_geo_lat_long(
     df :  metadata file, must have [idCol, address] columns
     idCol : unique id for merging metadata
     """
-    print("\nAdding Lat/Long, City, Region, Country")
+    logger.info("\nAdding Lat/Long, City, Region, Country")
     df_geo = get_lat_long(
         df,
         idCol,
         address,
-        use_cached_result=use_cached_result
+        use_cached_result=use_cached_result,
     )
 
     # merge geo data to main file

--- a/vdl_tools/shared_tools/climate_landscape/enrichment_pipeline.py
+++ b/vdl_tools/shared_tools/climate_landscape/enrichment_pipeline.py
@@ -25,7 +25,7 @@ from vdl_tools.shared_tools.web_summarization.website_summarization_cache_psql i
 from vdl_tools.shared_tools.web_summarization.website_summarization_psql import summarize_scraped_df
 
 from vdl_tools.shared_tools.model_caches.climate_relevance_cache import generate_climate_relevance_predictions
-import vdl_tools.scrape_enrich.geocode as geocode
+import vdl_tools.scrape_enrich.geocode_v2 as geocode
 import vdl_tools.scrape_enrich.process_images as images
 import vdl_tools.scrape_enrich.tags_from_text as tft
 import vdl_tools.shared_tools.common_functions as cf

--- a/vdl_tools/shared_tools/database_cache/data_migrations/versions/8fa633af5bbd_add_geocode_cache_table.py
+++ b/vdl_tools/shared_tools/database_cache/data_migrations/versions/8fa633af5bbd_add_geocode_cache_table.py
@@ -1,0 +1,44 @@
+"""add geocode cache table
+
+Revision ID: 8fa633af5bbd
+Revises: 5b984553ab92
+Create Date: 2026-06-18 15:42:50.806397
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '8fa633af5bbd'
+down_revision: Union[str, None] = '5b984553ab92'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # NOTE: autogenerate also proposed dropping `grantor_recipient_labeled_set`,
+    # `microapp_configs`, and `microapp_domains`. Those tables exist in the DB but
+    # are NOT SQLAlchemy models in this repo (owned by other services), so the
+    # drops were removed by hand. This migration only creates the `geocode` table.
+    op.create_table('geocode',
+    sa.Column('provider', sa.String(), nullable=False),
+    sa.Column('address_id', sa.String(), nullable=False),
+    sa.Column('address', sa.String(), nullable=False),
+    sa.Column('latitude', sa.Float(), nullable=True),
+    sa.Column('longitude', sa.Float(), nullable=True),
+    sa.Column('city', sa.String(), nullable=True),
+    sa.Column('state', sa.String(), nullable=True),
+    sa.Column('country', sa.String(), nullable=True),
+    sa.Column('response_full', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('num_errors', sa.Integer(), nullable=True),
+    sa.Column('date_added', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+    sa.Column('date_updated', sa.DateTime(), nullable=True),
+    sa.PrimaryKeyConstraint('provider', 'address_id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('geocode')

--- a/vdl_tools/shared_tools/database_cache/database_models/__init__.py
+++ b/vdl_tools/shared_tools/database_cache/database_models/__init__.py
@@ -1,5 +1,6 @@
 from .base import Base
 from .embedding import Embedding
+from .geocode import Geocode #pylint: disable=no-name-in-module
 from .linkedin_orgs import LinkedInOrganization #pylint: disable=no-name-in-module
 from .linkedin_people import LinkedInPerson #pylint: disable=no-name-in-module
 from .linkedin_base_employee import LinkedInBaseEmployee #pylint: disable=no-name-in-module
@@ -23,6 +24,7 @@ __all__ = (
     "CompanyCommercialDeal",
     "CompanyFundingRounds",
     "Embedding",
+    "Geocode",
     "Investor",
     "LinkedInOrganization",
     "LinkedInPerson",

--- a/vdl_tools/shared_tools/database_cache/database_models/geocode.py
+++ b/vdl_tools/shared_tools/database_cache/database_models/geocode.py
@@ -1,0 +1,44 @@
+from sqlalchemy import (
+    Column,
+    Float,
+    Integer,
+    String,
+)
+from sqlalchemy_utils import generic_repr
+from sqlalchemy.dialects.postgresql import JSONB
+
+from vdl_tools.shared_tools.database_cache.database_models.base import BaseMixin
+from vdl_tools.shared_tools.tools.unique_ids import create_deterministic_md5
+
+
+@generic_repr
+class Geocode(BaseMixin):
+    """Table to hold geocoded address results.
+
+    Keyed by (provider, address_id) where address_id is a deterministic md5 of the
+    *normalized* address string (parallels Embedding's (model_name, text_id)).
+    Failed lookups are stored as rows with num_errors set.
+    """
+    __tablename__ = 'geocode'
+
+    provider = Column(String, primary_key=True)
+    address_id = Column(String, primary_key=True)
+    address = Column(String, nullable=False)
+    latitude = Column(Float, nullable=True)
+    longitude = Column(Float, nullable=True)
+    city = Column(String, nullable=True)
+    state = Column(String, nullable=True)
+    country = Column(String, nullable=True)
+    response_full = Column(JSONB, nullable=True)
+    num_errors = Column(Integer, nullable=True)
+
+    def __init__(self, **kwargs):
+        if 'address_id' not in kwargs:
+            kwargs['address_id'] = self.create_address_id(kwargs["address"])
+        else:
+            assert kwargs['address_id'] == self.create_address_id(kwargs["address"])
+        super().__init__(**kwargs)
+
+    @classmethod
+    def create_address_id(cls, address):
+        return create_deterministic_md5(address)


### PR DESCRIPTION
## What

Replaces the geocode cache's S3 + local-filesystem backend (one S3 GET/PUT per address) with a Postgres-backed cache that does **one bulk SQL read** for all addresses, geocodes only the misses, then **chunked bulk upserts** (`INSERT ... ON CONFLICT DO UPDATE`). This mirrors the existing `EmbeddingCache` / `PromptResponse` caching pattern already used for OpenAI calls and web scraping.

## Why

The S3/file cache processes addresses one at a time — a network round-trip per address to read and per address to write — which is slow and awkward for large dataframes. Postgres lets us bulk-query stored results and bulk-insert new ones, the same way we already do for embeddings and GPT responses.

## Changes

- **New `geocode` table** (`Geocode` model) — composite PK `(provider, address_id)`, where `address_id = md5(normalized address)`. Stores lat/long/city/state/country, the raw Google response (`response_full` JSONB, for lineage), and `num_errors`. Long addresses are no longer special-cased (the md5 is the key; the full address lives in a column). Migration `8fa633af5bbd`.
- **`geocode_cache_sql.GeocodeCache`** — `get_geocode_obj_bulk` (bulk read), `_upsert_success_rows`/`_upsert_error_rows` (PG `ON CONFLICT`), and `bulk_get_cache_or_run` (read cache → geocode misses → chunked upsert). Owns the rate-limited `GoogleV3` geocoder.
- **`geocode_v2.py`** — same public API and output columns as v1 (`geocode_addresses`, `get_lat_long`, `add_geo_lat_long`), backed by Postgres. Re-exports the unchanged helpers (`clean_geo`, `reverse_geocode_addresses`, `get_component`).
- **`geocode_cache_backfill.py`** — one-time S3 → Postgres backfill so already-geocoded addresses are not re-billed to Google.
- **`enrichment_pipeline.py`** — switched its `geocode` import to `geocode_v2` (call sites unchanged).

The Google geocoding calls stay sequential + rate-limited (one address per request is a Google constraint; v1 already ran at 50/s). The win is on the cache I/O — thousands of S3 round-trips become a couple of SQL statements.

## Reviewer notes

- **Behavior change (v1 bug fix):** v1 wrote error markers but never read them, so failed lookups were re-geocoded (re-paying Google) on every run. v2 respects recorded failures — `max_errors=1` means a single recorded failure is not retried. Bump `max_errors` in `bulk_get_cache_or_run` if periodic retries are desired.
- **Alembic migration was hand-trimmed.** `alembic --autogenerate` against this DB also proposed dropping `microapp_configs`, `microapp_domains`, and `grantor_recipient_labeled_set` — tables that exist in the DB but are not ORM models in this repo (owned by other services). Those destructive drops were removed by hand; the migration only creates `geocode`.

## Verification

- Cache hit: second run of the same addresses → 0 Google calls, identical results.
- Pipeline parity: `add_geo_lat_long` + `clean_geo` produce the same columns as v1; empty-address rows merge to NaN.
- Backfill: 50-key run parsed + upserted cleanly; backfilled rows resolve from Postgres with 0 Google calls.
- Migration applied (DB head `8fa633af5bbd`); confirmed the three non-ORM tables are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
