### PR TITLE
Migrate taxonomy_mapping engines to SQL prompt-response cache + per-project match_schema

### DIFF
--- a/vdl_tools/shared_tools/openai/openai_api_utils.py
+++ b/vdl_tools/shared_tools/openai/openai_api_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 
 from openai import AsyncOpenAI, OpenAI
@@ -178,6 +179,107 @@ def get_completion(
         return response
     return response.output_parsed
 
+
+@contextlib.contextmanager
+def spy_openai(send: bool = True, printer=print, show_response: bool = True):
+    """Temporarily print every ``CLIENT.responses.parse`` call's payload.
+
+    Wrap any code that ends up calling the Responses API — ``get_completion``,
+    or the taxonomy-mapping / judge / coherence caches (which all funnel
+    through it) — and this prints the full request each call builds: the
+    ``model``, every extra kwarg (``temperature``, ``reasoning``, ...), the
+    ``text_format`` response class, and the ``input`` messages (or the bare
+    user string + ``instructions`` for reasoning models). The patch is
+    restored on exit.
+
+    Parameters
+    ----------
+    send : bool
+        ``True`` (default): print the request, call the real API, and
+        (if ``show_response``) print ``response.output_parsed``.
+        ``False``: print the request and raise *before* sending — no API
+        call. Use this with a single call; inside a multi-call loop the
+        raise is caught per call (recorded as an error) and the loop
+        continues, so you'd see every request but get no results.
+    printer : callable
+        Where to send output. Defaults to ``print``; pass e.g.
+        ``logger.info`` to route elsewhere.
+    show_response : bool
+        When ``send=True``, also print the parsed response. Default True.
+
+    Examples
+    --------
+    >>> from vdl_tools.shared_tools.openai.openai_api_utils import (
+    ...     get_completion, spy_openai,
+    ... )
+    >>> with spy_openai():
+    ...     get_completion(prompt="...", model="gpt-4.1", text="...",
+    ...                    text_format=MySchema)
+
+    >>> # see the request without spending a call:
+    >>> with spy_openai(send=False):
+    ...     try:
+    ...         cache.get_cache_or_run(given_id="x", text="...",
+    ...                                read_from_cache=False, write_to_cache=False)
+    ...     except RuntimeError:
+    ...         pass
+    """
+    orig = CLIENT.responses.parse
+    # ``parse`` is normally a class method (not an instance attribute), so
+    # restoring means deleting the instance-attribute shadow we add below
+    # — not reassigning, which would leave a stale bound method behind.
+    had_own_parse = "parse" in vars(CLIENT.responses)
+
+    def _wrapper(*args, **kwargs):
+        lines = ["", "=" * 72, "OpenAI responses.parse — request", "=" * 72]
+        lines.append(f"model       : {kwargs.get('model')}")
+        for k, v in kwargs.items():
+            if k in ("model", "input", "instructions", "text_format"):
+                continue
+            lines.append(f"{k:<12}: {v!r}")
+        tf = kwargs.get("text_format")
+        lines.append(f"text_format : {getattr(tf, '__name__', tf)}")
+        if args:
+            lines.append(f"(positional args: {args!r})")
+
+        if kwargs.get("instructions") is not None:
+            lines.append("\n--- instructions ---")
+            lines.append(str(kwargs["instructions"]))
+
+        inp = kwargs.get("input")
+        if isinstance(inp, list):
+            for m in inp:
+                if isinstance(m, dict):
+                    lines.append(f"\n--- input[{m.get('role', '?')}] ---")
+                    lines.append(str(m.get("content", m)))
+                else:
+                    lines.append("\n--- input[?] ---")
+                    lines.append(str(m))
+        elif inp is not None:
+            lines.append("\n--- input ---")
+            lines.append(str(inp))
+        lines.append("=" * 72)
+        printer("\n".join(lines))
+
+        if not send:
+            raise RuntimeError("spy_openai(send=False): stopped before sending")
+
+        resp = orig(*args, **kwargs)
+        if show_response:
+            printer(f"--- response.output_parsed ---\n"
+                    f"{getattr(resp, 'output_parsed', resp)}\n{'=' * 72}")
+        return resp
+
+    CLIENT.responses.parse = _wrapper
+    try:
+        yield
+    finally:
+        if had_own_parse:
+            CLIENT.responses.parse = orig
+        else:
+            # Remove our instance-attribute shadow so the original class
+            # method shows through again.
+            CLIENT.responses.__dict__.pop("parse", None)
 
 
 def contains_i_am(x):

--- a/vdl_tools/shared_tools/openai/prompt_response_cache_sql.py
+++ b/vdl_tools/shared_tools/openai/prompt_response_cache_sql.py
@@ -250,7 +250,7 @@ class PromptResponseCacheSQL():
         if not any([prompt is not None, prompt_str, prompt_id]):
             raise Exception("Need to give at least one of prompt, prompt_str, prompt_id")
 
-        self.session = session or get_session()
+        self.session = session
         self.prompt = self._set_prompt_obj(
             prompt=prompt,
             prompt_str=prompt_str,

--- a/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
@@ -77,6 +77,7 @@ the same data as a human-readable Markdown report.
 """
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Iterable
 
 import pandas as pd
@@ -369,13 +370,20 @@ def check_taxonomy_coherence(
 
     cache = CoherenceAuditCache(session=session, model=model)
 
-    # Build (given_id, user_text) pairs. given_id is taxonomy-agnostic —
-    # the system prompt + AuditResponse schema (captured in prompt_id)
-    # already distinguish this audit from other tools; level + name
-    # uniquely identify a parent within one taxonomy.
+    # Build (given_id, user_text) pairs. The system prompt + AuditResponse
+    # schema (captured in prompt_id) distinguish this audit from other
+    # tools. Within one taxonomy, level + name is NOT unique — the same
+    # node name can recur under different parents (e.g. "Buildings" under
+    # two pillars), and those parents have different children. Since
+    # ``bulk_get_cache_or_run`` returns a dict keyed by given_id alone,
+    # a bare "level|name" key would let two such parents collide and share
+    # one response. Append a short hash of the user prompt (parent
+    # definition + children) so distinct parents get distinct keys; two
+    # parents with genuinely identical audits still collapse (correct),
+    # and an unchanged taxonomy re-runs to a full cache hit because the
+    # hash is content-derived.
     requests: list[tuple[str, str]] = []
     for t in tasks:
-        given_id = f"{t['parent_level']}|{t['parent_name']}"
         user_text = _build_user_prompt(
             parent_level=t["parent_level"],
             child_level=t["child_level"],
@@ -383,6 +391,8 @@ def check_taxonomy_coherence(
             parent_definition=t["parent_definition"],
             children=t["children"],
         )
+        content_hash = hashlib.sha1(user_text.encode("utf-8")).hexdigest()[:8]
+        given_id = f"{t['parent_level']}|{t['parent_name']}|{content_hash}"
         requests.append((given_id, user_text))
 
     # Restore deterministic audits (temperature=0); reasoning models

--- a/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
@@ -66,9 +66,11 @@ Library entry point::
 All OpenAI calls flow through the SQL prompt/response cache
 (``CoherenceAuditCache`` extends ``InstructorPRC``). Cache keys: the
 fixed system prompt + the ``AuditResponse`` schema -> ``prompt_id``;
-``f"{parent_level}|{parent_name}"`` -> ``given_id``; hash of the user
-prompt body (parent definition + children) -> ``text_id``. Re-running
-the audit against an unchanged taxonomy is a no-API run.
+``f"{parent_level}|{parent_name}|{hash(user prompt body)}"`` ->
+``given_id`` (the content hash disambiguates same-named parents that
+recur at one level under different parents); hash of the user prompt
+body (parent definition + children) -> ``text_id``. Re-running the
+audit against an unchanged taxonomy is a no-API run.
 
 The output frame has one row per parent node with: parent level/name,
 n_children, verdict (ok/minor_gaps/major_gaps), summary, coverage_gaps,

--- a/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
@@ -84,6 +84,7 @@ from pydantic import BaseModel
 
 from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
 from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
+from vdl_tools.shared_tools.openai.openai_api_utils import is_reasoning_model
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +281,7 @@ def check_taxonomy_coherence(
     definition_col: str = "Definition",
     read_from_cache: bool = True,
     write_to_cache: bool = True,
+    temperature: float | None = 0,
 ) -> pd.DataFrame:
     """Audit parent-child coherence at every non-leaf level transition.
 
@@ -314,6 +316,11 @@ def check_taxonomy_coherence(
         Forwarded to ``bulk_get_cache_or_run``. Defaults of ``True``
         match legacy behavior; pass ``read_from_cache=False`` to force a
         full re-run, or ``write_to_cache=False`` for a read-only audit.
+    temperature
+        Sampling temperature for the audit model. Defaults to ``0`` for
+        deterministic audits (matching the legacy path). Automatically
+        suppressed for reasoning models (``gpt-5*``), which reject it.
+        Pass ``None`` to omit entirely.
 
     Returns
     -------
@@ -378,11 +385,18 @@ def check_taxonomy_coherence(
         )
         requests.append((given_id, user_text))
 
+    # Restore deterministic audits (temperature=0); reasoning models
+    # (gpt-5*) reject the param, so suppress it for them.
+    api_kwargs: dict[str, Any] = {}
+    if temperature is not None and not is_reasoning_model(model):
+        api_kwargs["temperature"] = temperature
+
     responses = cache.bulk_get_cache_or_run(
         given_ids_texts=requests,
         max_workers=max_workers,
         read_from_cache=read_from_cache,
         write_to_cache=write_to_cache,
+        **api_kwargs,
     )
 
     rows: list[dict[str, Any]] = []

--- a/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
@@ -283,6 +283,7 @@ def check_taxonomy_coherence(
     read_from_cache: bool = True,
     write_to_cache: bool = True,
     temperature: float | None = 0,
+    filter_by_model: bool = True,
 ) -> pd.DataFrame:
     """Audit parent-child coherence at every non-leaf level transition.
 
@@ -322,6 +323,13 @@ def check_taxonomy_coherence(
         deterministic audits (matching the legacy path). Automatically
         suppressed for reasoning models (``gpt-5*``), which reject it.
         Pass ``None`` to omit entirely.
+    filter_by_model
+        When True (default), scope ``CoherenceAuditCache`` lookups by
+        ``model`` so auditing the same taxonomy under a different model
+        does not silently reuse the prior model's cached audits. The
+        cache write PK always stamps ``model_name``, so this is cost-free
+        on same-model re-runs; pass False to restore the legacy
+        cross-model-sharing behavior.
 
     Returns
     -------
@@ -368,7 +376,8 @@ def check_taxonomy_coherence(
     if not tasks:
         return pd.DataFrame()
 
-    cache = CoherenceAuditCache(session=session, model=model)
+    cache = CoherenceAuditCache(
+        session=session, model=model, filter_by_model=filter_by_model)
 
     # Build (given_id, user_text) pairs. The system prompt + AuditResponse
     # schema (captured in prompt_id) distinguish this audit from other

--- a/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/check_taxonomy_coherence.py
@@ -47,19 +47,28 @@ Usage
 -----
 Library entry point::
 
+    from vdl_tools.shared_tools.database_cache.database_utils import get_session
     from vdl_tools.shared_tools.taxonomy_mapping.check_taxonomy_coherence import (
         check_taxonomy_coherence,
     )
 
-    df = check_taxonomy_coherence(
-        tables=tables,            # dict[int, pd.DataFrame] keyed by level idx
-        levels=ONEEARTH_LEVELS,   # list of level dicts, same shape as the engine uses
-        client=client,
-        model="gpt-5.4-nano",
-        max_workers=16,
-        definition_col="Definition",
-    )
+    with get_session() as session:
+        df = check_taxonomy_coherence(
+            tables=tables,            # dict[int, pd.DataFrame] keyed by level idx
+            levels=ONEEARTH_LEVELS,   # list of level dicts, same shape as the engine uses
+            session=session,
+            model="gpt-5.4-nano",
+            max_workers=16,
+            definition_col="Definition",
+        )
     df.to_excel("coherence_audit.xlsx", index=False)
+
+All OpenAI calls flow through the SQL prompt/response cache
+(``CoherenceAuditCache`` extends ``InstructorPRC``). Cache keys: the
+fixed system prompt + the ``AuditResponse`` schema -> ``prompt_id``;
+``f"{parent_level}|{parent_name}"`` -> ``given_id``; hash of the user
+prompt body (parent definition + children) -> ``text_id``. Re-running
+the audit against an unchanged taxonomy is a no-API run.
 
 The output frame has one row per parent node with: parent level/name,
 n_children, verdict (ok/minor_gaps/major_gaps), summary, coverage_gaps,
@@ -68,12 +77,13 @@ the same data as a human-readable Markdown report.
 """
 from __future__ import annotations
 
-import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Iterable
 
 import pandas as pd
-from openai import OpenAI
+from pydantic import BaseModel
+
+from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
+from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
 
 
 # ---------------------------------------------------------------------------
@@ -204,64 +214,80 @@ def _children_of(
     return out
 
 
-def _audit_one(
-    *,
-    client: OpenAI,
-    model: str,
-    parent_level: str,
-    child_level: str,
-    parent_name: str,
-    parent_definition: str,
-    children: list[dict[str, str]],
-) -> dict[str, Any]:
-    """Call the LLM for one parent-children group and parse the JSON."""
-    user = _build_user_prompt(
-        parent_level=parent_level,
-        child_level=child_level,
-        parent_name=parent_name,
-        parent_definition=parent_definition,
-        children=children,
-    )
-    resp = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": user},
-        ],
-        response_format={"type": "json_object"},
-        temperature=0,
-    )
-    raw = resp.choices[0].message.content or "{}"
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return {
-            "verdict": "parse_error",
-            "summary": f"non-JSON model output: {raw[:200]}",
-            "coverage_gaps": [],
-            "completeness_gaps": [],
-            "suggested_edits": "",
-        }
+# ---------------------------------------------------------------------------
+# Pydantic response schema + cache class
+# ---------------------------------------------------------------------------
+
+class Gap(BaseModel):
+    """One coverage / completeness / cohesion finding for a parent-child group."""
+
+    child: str = ""
+    issue: str = ""
 
 
-def _gaps_to_text(gaps: list[dict[str, str]] | None) -> str:
-    """Flatten a list of {child, issue} dicts into a single cell string."""
+class AuditResponse(BaseModel):
+    """Structured-output schema for one parent's coherence audit."""
+
+    verdict: str = "unknown"  # "ok" | "minor_gaps" | "major_gaps"
+    summary: str = ""
+    coverage_gaps: list[Gap] = []
+    completeness_gaps: list[Gap] = []
+    cohesion_gaps: list[Gap] = []
+    suggested_edits: str = ""
+
+
+class CoherenceAuditCache(InstructorPRC):
+    """SQL-cached cache class for the coherence audit.
+
+    One instance per (system_prompt, model). Reused across every
+    parent-children group in a single ``check_taxonomy_coherence`` call.
+    """
+
+    def __init__(
+        self,
+        session,
+        model: str = DEFAULT_MODEL,
+        store_results: bool = True,
+        filter_by_model: bool = False,
+    ):
+        super().__init__(
+            session=session,
+            prompt_str=SYSTEM_PROMPT,
+            prompt_name="taxonomy_coherence_audit",
+            response_model=AuditResponse,
+            model=model,
+            filter_by_model=filter_by_model,
+            store_results=store_results,
+        )
+
+
+def _gaps_to_text(gaps: Iterable[Gap]) -> str:
+    """Flatten a list of ``Gap`` objects into a single cell string."""
     if not gaps:
         return ""
-    return "\n".join(f"- {g.get('child','?')}: {g.get('issue','')}".strip()
-                     for g in gaps)
+    return "\n".join(
+        f"- {(g.child or '?')}: {g.issue}".strip() for g in gaps
+    )
 
 
 def check_taxonomy_coherence(
     *,
     tables: dict[int, pd.DataFrame],
     levels: list[dict[str, Any]],
-    client: OpenAI,
+    session,
     model: str,
     max_workers: int = 16,
     definition_col: str = "Definition",
+    read_from_cache: bool = True,
+    write_to_cache: bool = True,
 ) -> pd.DataFrame:
     """Audit parent-child coherence at every non-leaf level transition.
+
+    Every per-parent OpenAI call flows through the SQL prompt/response
+    cache: one ``CoherenceAuditCache.bulk_get_cache_or_run`` for the
+    whole audit, parallelism bounded by ``max_workers`` (cache's
+    internal pool — the SQLAlchemy session is touched only on the main
+    thread).
 
     Parameters
     ----------
@@ -275,20 +301,26 @@ def check_taxonomy_coherence(
         dicts with ``idx``, ``name``, ``key_col``, ``parent_filters``.
         The last level is treated as a leaf and is never audited as a
         parent.
-    client, model
-        OpenAI client + model id used for the audit calls. JSON
-        response format is required.
+    session
+        SQLAlchemy session for the SQL prompt/response cache. Build via
+        ``vdl_tools.shared_tools.database_cache.database_utils.get_session``.
+    model
+        OpenAI model id.
     max_workers
-        Thread pool size — audits run in parallel, one parent per task.
+        Concurrency cap for the cache's API worker pool.
     definition_col
         Column name carrying the definition text on every level frame.
+    read_from_cache, write_to_cache
+        Forwarded to ``bulk_get_cache_or_run``. Defaults of ``True``
+        match legacy behavior; pass ``read_from_cache=False`` to force a
+        full re-run, or ``write_to_cache=False`` for a read-only audit.
 
     Returns
     -------
     A DataFrame with one row per audited parent: ``parent_level``,
     ``parent_name``, ``n_children``, ``verdict``, ``summary``,
-    ``coverage_gaps``, ``completeness_gaps``, ``suggested_edits``,
-    ``parent_definition``.
+    ``coverage_gaps``, ``completeness_gaps``, ``cohesion_gaps``,
+    ``suggested_edits``, ``parent_definition``.
     """
     tasks: list[dict[str, Any]] = []
 
@@ -325,38 +357,74 @@ def check_taxonomy_coherence(
     print(f"Auditing {len(tasks)} parent-children groups "
           f"with {max_workers} worker(s) using {model}")
 
+    if not tasks:
+        return pd.DataFrame()
+
+    cache = CoherenceAuditCache(session=session, model=model)
+
+    # Build (given_id, user_text) pairs. given_id is taxonomy-agnostic —
+    # the system prompt + AuditResponse schema (captured in prompt_id)
+    # already distinguish this audit from other tools; level + name
+    # uniquely identify a parent within one taxonomy.
+    requests: list[tuple[str, str]] = []
+    for t in tasks:
+        given_id = f"{t['parent_level']}|{t['parent_name']}"
+        user_text = _build_user_prompt(
+            parent_level=t["parent_level"],
+            child_level=t["child_level"],
+            parent_name=t["parent_name"],
+            parent_definition=t["parent_definition"],
+            children=t["children"],
+        )
+        requests.append((given_id, user_text))
+
+    responses = cache.bulk_get_cache_or_run(
+        given_ids_texts=requests,
+        max_workers=max_workers,
+        read_from_cache=read_from_cache,
+        write_to_cache=write_to_cache,
+    )
+
     rows: list[dict[str, Any]] = []
-
-    def _run(task: dict[str, Any]) -> dict[str, Any]:
-        out = _audit_one(client=client, model=model, **task)
-        return {
-            "parent_level": task["parent_level"],
-            "parent_name": task["parent_name"],
-            "n_children": len(task["children"]),
-            "verdict": out.get("verdict", "unknown"),
-            "summary": out.get("summary", ""),
-            "coverage_gaps": _gaps_to_text(out.get("coverage_gaps")),
-            "completeness_gaps": _gaps_to_text(out.get("completeness_gaps")),
-            "cohesion_gaps": _gaps_to_text(out.get("cohesion_gaps")),
-            "suggested_edits": out.get("suggested_edits", "") or "",
-            "parent_definition": task["parent_definition"],
+    for t, (given_id, _) in zip(tasks, requests):
+        base = {
+            "parent_level": t["parent_level"],
+            "parent_name": t["parent_name"],
+            "n_children": len(t["children"]),
+            "parent_definition": t["parent_definition"],
         }
+        resp = responses.get(given_id)
+        if resp is None:
+            rows.append({**base,
+                         "verdict": "parse_error",
+                         "summary": "API call failed",
+                         "coverage_gaps": "",
+                         "completeness_gaps": "",
+                         "cohesion_gaps": "",
+                         "suggested_edits": ""})
+            continue
+        try:
+            audit = AuditResponse.model_validate_json(resp["response_text"])
+        except Exception as exc:  # noqa: BLE001
+            rows.append({**base,
+                         "verdict": "parse_error",
+                         "summary": f"parse error: {exc}",
+                         "coverage_gaps": "",
+                         "completeness_gaps": "",
+                         "cohesion_gaps": "",
+                         "suggested_edits": ""})
+            continue
+        rows.append({
+            **base,
+            "verdict": audit.verdict or "unknown",
+            "summary": audit.summary or "",
+            "coverage_gaps": _gaps_to_text(audit.coverage_gaps),
+            "completeness_gaps": _gaps_to_text(audit.completeness_gaps),
+            "cohesion_gaps": _gaps_to_text(audit.cohesion_gaps),
+            "suggested_edits": audit.suggested_edits or "",
+        })
 
-    if max_workers <= 1:
-        for t in tasks:
-            r = _run(t)
-            rows.append(r)
-            print(f"  [{r['parent_level']}] {r['parent_name']} -> "
-                  f"{r['verdict']} ({r['n_children']} children)")
-    else:
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            futures = {ex.submit(_run, t): t for t in tasks}
-            for i, fut in enumerate(as_completed(futures), start=1):
-                r = fut.result()
-                rows.append(r)
-                print(f"  [{i}/{len(tasks)}] [{r['parent_level']}] "
-                      f"{r['parent_name']} -> {r['verdict']} "
-                      f"({r['n_children']} children)")
+    session.commit()
 
     out_df = pd.DataFrame(rows)
     # Stable ordering: level order (per `levels`), then parent name.

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
@@ -78,6 +78,7 @@ from pydantic import BaseModel
 
 from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
 from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
+from vdl_tools.shared_tools.openai.openai_api_utils import is_reasoning_model
 
 
 # ---------------------------------------------------------------------------
@@ -833,6 +834,7 @@ def run_judge_evaluation(
     driver_script_name: str = "evaluate_*.py",
     read_from_cache: bool = True,
     write_to_cache: bool = True,
+    temperature: float | None = 0,
 ) -> None:
     """Run the full judge pipeline: collect bundles, judge, summarize, write outputs.
 
@@ -877,6 +879,11 @@ def run_judge_evaluation(
         model_name)`` and overwrite each other's cache row, thrashing
         forever on every entity whose user prompt differs between the
         two passes. Default ``""`` (no prefix).
+    temperature
+        Sampling temperature for the judge model. Defaults to ``0`` for
+        deterministic judging (matching the legacy path). Automatically
+        suppressed for reasoning models (``gpt-5*``), which reject it.
+        Pass ``None`` to omit entirely.
     """
     if not per_row_path.exists():
         raise FileNotFoundError(f"Per-row file not found: {per_row_path}")
@@ -926,8 +933,10 @@ def run_judge_evaluation(
         # When from_scored is used, also try the verdicts file derived
         # from from_scored's location rather than output_path's.
         candidate_v = from_scored.with_name(
-            from_scored.stem.replace("_quality_scored",
-                                      f"_quality_{config.verdict_top_label.lower()}_verdicts")
+            from_scored.stem.replace(
+                "_quality_scored",
+                f"_quality_{config.verdict_top_label.lower()}_verdicts"
+            )
             + from_scored.suffix
         )
         if candidate_v.exists():
@@ -988,11 +997,18 @@ def run_judge_evaluation(
             requests.append((given_id, user_text))
             bundle_by_given_id[given_id] = (eid, b)
 
+        # Restore deterministic judging (temperature=0); reasoning models
+        # (gpt-5*) reject the param, so suppress it for them.
+        api_kwargs: dict[str, Any] = {}
+        if temperature is not None and not is_reasoning_model(judge_model):
+            api_kwargs["temperature"] = temperature
+
         responses = cache.bulk_get_cache_or_run(
             given_ids_texts=requests,
             max_workers=workers,
             read_from_cache=read_from_cache,
             write_to_cache=write_to_cache,
+            **api_kwargs,
         )
         session.commit()
 

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
@@ -835,6 +835,7 @@ def run_judge_evaluation(
     read_from_cache: bool = True,
     write_to_cache: bool = True,
     temperature: float | None = 0,
+    filter_by_model: bool = True,
 ) -> None:
     """Run the full judge pipeline: collect bundles, judge, summarize, write outputs.
 
@@ -879,6 +880,16 @@ def run_judge_evaluation(
         model_name)`` and overwrite each other's cache row, thrashing
         forever on every entity whose user prompt differs between the
         two passes. Default ``""`` (no prefix).
+    filter_by_model
+        When True (default), scope ``JudgeCache`` lookups by
+        ``judge_model`` so re-judging the same entities under a
+        different judge model does not silently reuse the prior model's
+        cached verdicts. Orthogonal to ``given_id_prefix``: the prefix
+        namespaces *different classifier outputs* judged by one model,
+        while this namespaces *different judge models* over the same
+        output. Cost-free on same-model re-runs (the write PK always
+        stamps ``model_name``); pass False to restore the legacy
+        cross-model-sharing behavior.
     temperature
         Sampling temperature for the judge model. Defaults to ``0`` for
         deterministic judging (matching the legacy path). Automatically
@@ -972,6 +983,7 @@ def run_judge_evaluation(
             session=session,
             system_prompt=system_prompt,
             model=judge_model,
+            filter_by_model=filter_by_model,
         )
 
         # Build one (given_id, user_text) per entity. given_id is the

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
@@ -827,6 +827,7 @@ def run_judge_evaluation(
     output_path: Path | None = None,
     from_scored: Path | None = None,
     method: str = "new",
+    given_id_prefix: str = "",
     judge_model: str = "gpt-4.1",
     workers: int = 32,
     driver_script_name: str = "evaluate_*.py",
@@ -867,6 +868,15 @@ def run_judge_evaluation(
         ``True`` match legacy behavior; pass ``read_from_cache=False``
         to force a re-run, or ``write_to_cache=False`` for a read-only
         judging pass.
+    given_id_prefix
+        Optional namespace prepended to each entity's cache ``given_id``
+        as ``"<prefix>::<entity_id>"``. Use when judging the same
+        entities twice over different classifier outputs in the same
+        session (e.g. comparing an old baseline vs. a new run) — without
+        a distinct prefix the two passes share ``(prompt_id, given_id,
+        model_name)`` and overwrite each other's cache row, thrashing
+        forever on every entity whose user prompt differs between the
+        two passes. Default ``""`` (no prefix).
     """
     if not per_row_path.exists():
         raise FileNotFoundError(f"Per-row file not found: {per_row_path}")
@@ -956,15 +966,25 @@ def run_judge_evaluation(
         )
 
         # Build one (given_id, user_text) per entity. given_id is the
-        # entity id; text is the user-message body (name + description +
-        # the classifier's matches at every level). Changing any of
-        # those invalidates only that entity's cached judgment.
+        # entity id (optionally prefixed); text is the user-message body
+        # (name + description + the classifier's matches at every level).
+        # Changing any of those invalidates only that entity's cached
+        # judgment.
+        #
+        # ``given_id_prefix`` lets a caller judge the same entity twice
+        # over different classifier outputs in the same DB without the
+        # two runs overwriting each other's cache row — the cache PK is
+        # ``(prompt_id, given_id, model_name)``, so two passes that
+        # share ``str(eid)`` but differ in user prompt would thrash.
+        # Pass e.g. ``given_id_prefix="new"`` and ``"old"`` to namespace
+        # them.
+        prefix = f"{given_id_prefix}::" if given_id_prefix else ""
         requests: list[tuple[str, str]] = []
         bundle_by_given_id: dict[str, tuple[Any, dict[str, Any]]] = {}
         for eid, b in bundles.items():
             user_text = build_user_prompt(b["name"], b["description"],
                                           b["matches"], config)
-            given_id = str(eid)
+            given_id = f"{prefix}{eid}"
             requests.append((given_id, user_text))
             bundle_by_given_id[given_id] = (eid, b)
 

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_judge.py
@@ -69,14 +69,15 @@ LLM calls.
 from __future__ import annotations
 
 import ast
-import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping
 
 import pandas as pd
-from openai import OpenAI
+from pydantic import BaseModel
+
+from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
+from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +98,86 @@ DEFAULT_STRICTNESS = """Strictness:
 
 
 # ---------------------------------------------------------------------------
+# Structured-output schema for the judge call
+# ---------------------------------------------------------------------------
+# The judge response is a fixed shape across all configs:
+#
+#   {
+#     "matches_by_level": [
+#       {"level": "Pillar", "matches": [{"match": "...", "score": "good|weak|bad", "reason": "..."}, ...]},
+#       ...
+#     ],
+#     "alignment_verdict": {"verdict": "correct|wrong|...", "reason": "..."}
+#   }
+#
+# A list-of-LevelMatches (rather than a dict keyed by level name) keeps the
+# Pydantic schema strict enough for OpenAI's structured-output mode, which
+# rejects open-ended object types. The level label inside the prompt — and
+# the verdict's enum values — still vary per ``JudgeConfig``, but the
+# top-level keys are fixed.
+
+class MatchScore(BaseModel):
+    """One per-match scoring entry."""
+
+    match: str = ""
+    score: str = ""  # "good" | "weak" | "bad"
+    reason: str = ""
+
+
+class LevelMatches(BaseModel):
+    """All scored matches for one taxonomy level."""
+
+    level: str = ""
+    matches: list[MatchScore] = []
+
+
+class AlignmentVerdict(BaseModel):
+    """Top-level alignment verdict for the entity as a whole."""
+
+    verdict: str = ""  # "correct" | "wrong" | "ambiguous" | "mixed" | "no_<X>_expected"
+    reason: str = ""
+
+
+class JudgmentResponse(BaseModel):
+    """Full structured-output response from one judge call."""
+
+    matches_by_level: list[LevelMatches] = []
+    alignment_verdict: AlignmentVerdict | None = None
+
+
+class JudgeCache(InstructorPRC):
+    """SQL-backed cache for one judge run.
+
+    Construct once per (system_prompt, model); reuse across every entity
+    in a single ``run_judge_evaluation`` call. Cache rows are keyed by
+    (prompt_id, given_id, text_id): the system prompt + the
+    ``JudgmentResponse`` schema together set ``prompt_id``; the
+    per-entity ``entity_id`` is the ``given_id``; ``text_id`` hashes the
+    user-message body (entity name + description + the classifier's
+    matches at every level). Changing the classifier's output for an
+    entity invalidates only that entity's cached judgment.
+    """
+
+    def __init__(
+        self,
+        session,
+        system_prompt: str,
+        model: str = DEFAULT_MODEL,
+        store_results: bool = True,
+        filter_by_model: bool = False,
+    ):
+        super().__init__(
+            session=session,
+            prompt_str=system_prompt,
+            prompt_name="hierarchical_taxonomy_judge",
+            response_model=JudgmentResponse,
+            model=model,
+            filter_by_model=filter_by_model,
+            store_results=store_results,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 
@@ -109,11 +190,13 @@ class JudgeConfig:
     drivers override what they need:
 
     - **All projects** must supply: ``levels``, ``taxonomy_intro``,
-      ``new_level_cols``, ``load_taxonomy_tables``,
-      ``build_openai_client``.
+      ``new_level_cols``, ``load_taxonomy_tables``. The judge call
+      itself flows through the SQL prompt-response cache, so a
+      SQLAlchemy ``session`` is passed at run time to
+      ``run_judge_evaluation`` rather than configured here.
     - **Sector-based domains** (Drawdown) override
       ``verdict_top_label="Sector"`` (which auto-derives
-      ``verdict_key``, ``verdict_no_match_value``, output column).
+      ``verdict_no_match_value``, output column).
     - **Research / non-org entity domains** (hopper_dean) override
       ``entity_id_col``, ``entity_name_col``,
       ``entity_description_col``, ``entity_label_in_prompt``,
@@ -161,10 +244,9 @@ class JudgeConfig:
     entity_label_plural: str = "entities"           # "entities" / "projects" — used in report prose
     description_label_in_prompt: str = "Description"  # "Description:" / "Abstract:"
 
-    # ---- Taxonomy + OpenAI client builders ----
+    # ---- Taxonomy loader ----
     load_taxonomy_tables: Callable[[], dict[int, pd.DataFrame]] = None
     taxonomy_label_path_fn: Callable[[], Path] | None = None  # optional; reports the taxonomy file name
-    build_openai_client: Callable[[], OpenAI] = None
 
     # ---- Prompt customization (overrides) ----
     scoring_rubric: str = DEFAULT_SCORING_RUBRIC
@@ -175,11 +257,6 @@ class JudgeConfig:
     failure_sample_n: int = 10
 
     # ---- Derived properties ----
-    @property
-    def verdict_key(self) -> str:
-        # e.g., "pillar_alignment", "sector_alignment"
-        return f"{self.verdict_top_label.lower()}_alignment"
-
     @property
     def verdict_no_match_value(self) -> str:
         # e.g., "no_pillar_expected", "no_sector_expected"
@@ -201,8 +278,6 @@ class JudgeConfig:
 
 def build_judge_system_prompt(config: JudgeConfig) -> str:
     """Assemble the judge system prompt from the config."""
-    levels_lines = "\n  ".join(f'"{lbl}":     [...]' for lbl in config.level_labels)
-
     verdict_spec = (
         f"PART 2 — {config.verdict_top_label} alignment verdict. Given the "
         f"description, decide whether the chosen {config.verdict_top_label}(s) "
@@ -214,21 +289,24 @@ def build_judge_system_prompt(config: JudgeConfig) -> str:
         f'- "{config.verdict_no_match_value}": the description does not describe work in scope; the entity should have returned no {config.verdict_top_label} match.'
     )
 
+    level_label_list = ", ".join(f'"{lbl}"' for lbl in config.level_labels)
     output_schema = (
         "Output JSON of the form:\n"
         "{\n"
-        '  "matches": {\n'
-        + "\n".join(f'    "{lbl}":     [{{"match": "<exact name>", "score": "good|weak|bad", "reason": "<one sentence>"}}],'
-                    for lbl in config.level_labels)
-        + "\n  },\n"
-        f'  "{config.verdict_key}": {{\n'
+        '  "matches_by_level": [\n'
+        '    {"level": "<one of: ' + level_label_list + '>",\n'
+        '     "matches": [{"match": "<exact name>", "score": "good|weak|bad", "reason": "<one sentence>"}]},\n'
+        "    ...\n"
+        "  ],\n"
+        '  "alignment_verdict": {\n'
         f'    "verdict": "correct|wrong|ambiguous|mixed|{config.verdict_no_match_value}",\n'
         '    "reason": "<one sentence>"\n'
         "  }\n"
         "}\n\n"
-        "The order of matches must match the order shown in the input. "
-        "Use the exact match names you were shown. If a level has no matches, "
-        'omit it from "matches".'
+        "Emit one entry per level shown in the input, in the same order. "
+        "Use the exact match names you were shown. If a level has no "
+        'matches in the input, emit an entry with an empty "matches" '
+        "list."
     )
 
     return "\n\n".join([
@@ -435,71 +513,43 @@ def build_user_prompt(
     )
 
 
-def judge_entity(
-    client: OpenAI,
-    model: str,
+def _parse_judgment(
     eid: str,
     name: str,
-    description: str,
     matches: dict[str, list[tuple[str, str]]],
+    judgment: JudgmentResponse | None,
     config: JudgeConfig,
-    system_prompt: str,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Score every match for one entity, plus the top-level verdict.
+    """Convert one parsed ``JudgmentResponse`` into per-match rows + verdict row.
 
-    Returns ``(per-match rows, verdict row)``. Verdict row is ``None``
-    when the judge call failed (the per-match rows list is empty in
-    that case).
+    Returns ``(per-match rows, verdict row)``. Both are empty/None when
+    ``judgment`` is ``None`` — i.e., the API call failed and the cache
+    surfaced no response.
     """
-    user_prompt = build_user_prompt(name, description, matches, config)
-
-    try:
-        resp = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"},
-            temperature=0,
-        )
-    except Exception as exc:  # noqa: BLE001
-        display_name = str(name)[:60]
-        print(f"  [error] {display_name}: {exc}")
-        return [], None
-
-    raw = resp.choices[0].message.content or "{}"
-    try:
-        judgment = json.loads(raw)
-    except json.JSONDecodeError:
-        print(f"  [warn] bad JSON for {str(name)[:60]}: {raw[:200]}")
+    if judgment is None:
         return [], None
 
     rows: list[dict[str, Any]] = []
-    matches_block = judgment.get("matches") or {}
-    if isinstance(matches_block, dict):
-        for level_label, scored in matches_block.items():
-            if not isinstance(scored, list):
+    for level_block in judgment.matches_by_level:
+        level_label = (level_block.level or "").strip()
+        if not level_label:
+            continue
+        for entry in level_block.matches:
+            score = (entry.score or "").strip().lower()
+            if score not in {"good", "weak", "bad"}:
                 continue
-            for entry in scored:
-                if not isinstance(entry, dict):
-                    continue
-                score = str(entry.get("score", "")).strip().lower()
-                if score not in {"good", "weak", "bad"}:
-                    continue
-                rows.append({
-                    config.entity_id_col: eid,
-                    config.entity_name_col: name,
-                    "level": level_label,
-                    "match": str(entry.get("match", "")).strip(),
-                    "score": score,
-                    "reason": str(entry.get("reason", "")).strip(),
-                })
+            rows.append({
+                config.entity_id_col: eid,
+                config.entity_name_col: name,
+                "level": level_label,
+                "match": (entry.match or "").strip(),
+                "score": score,
+                "reason": (entry.reason or "").strip(),
+            })
 
-    pa = judgment.get(config.verdict_key) or {}
-    if isinstance(pa, dict):
-        verdict = str(pa.get("verdict", "")).strip().lower()
-        verdict_reason = str(pa.get("reason", "")).strip()
+    if judgment.alignment_verdict is not None:
+        verdict = (judgment.alignment_verdict.verdict or "").strip().lower()
+        verdict_reason = (judgment.alignment_verdict.reason or "").strip()
     else:
         verdict, verdict_reason = "", ""
 
@@ -773,12 +823,15 @@ def run_judge_evaluation(
     config: JudgeConfig,
     per_row_path: Path,
     *,
+    session=None,
     output_path: Path | None = None,
     from_scored: Path | None = None,
     method: str = "new",
     judge_model: str = "gpt-4.1",
     workers: int = 32,
     driver_script_name: str = "evaluate_*.py",
+    read_from_cache: bool = True,
+    write_to_cache: bool = True,
 ) -> None:
     """Run the full judge pipeline: collect bundles, judge, summarize, write outputs.
 
@@ -788,6 +841,9 @@ def run_judge_evaluation(
         Per-project ``JudgeConfig``.
     per_row_path
         Path to the per-row xlsx or CSV produced by the classifier.
+    session
+        SQLAlchemy session for the SQL prompt/response cache. Required
+        unless ``from_scored`` is set (in which case no API calls happen).
     output_path
         Override the scored-matches output path. Default: alongside
         the per-row file with ``_quality_scored`` appended to the
@@ -802,10 +858,15 @@ def run_judge_evaluation(
     judge_model
         OpenAI model id for the judge.
     workers
-        Thread pool size for parallel judge calls.
+        Concurrency cap for the cache's API worker pool.
     driver_script_name
         Filename of the driver script that called this — used in the
         report's "Generated by …" line for provenance.
+    read_from_cache, write_to_cache
+        Forwarded to ``JudgeCache.bulk_get_cache_or_run``. Defaults of
+        ``True`` match legacy behavior; pass ``read_from_cache=False``
+        to force a re-run, or ``write_to_cache=False`` for a read-only
+        judging pass.
     """
     if not per_row_path.exists():
         raise FileNotFoundError(f"Per-row file not found: {per_row_path}")
@@ -871,6 +932,13 @@ def run_judge_evaluation(
             )
         print(f"  {len(scored_df)} scored matches loaded")
     else:
+        if session is None:
+            raise ValueError(
+                "run_judge_evaluation: `session` is required for live judge "
+                "calls (only `from_scored` runs can omit it). Build one with "
+                "`vdl_tools.shared_tools.database_cache.database_utils.get_session`."
+            )
+
         tables = config.load_taxonomy_tables()
         lookups = build_definition_lookups(tables, config)
 
@@ -881,46 +949,53 @@ def run_judge_evaluation(
 
         system_prompt = build_judge_system_prompt(config)
         print(f"Calling judge ({judge_model}) with {workers} worker(s)...")
-        client = config.build_openai_client()
+        cache = JudgeCache(
+            session=session,
+            system_prompt=system_prompt,
+            model=judge_model,
+        )
+
+        # Build one (given_id, user_text) per entity. given_id is the
+        # entity id; text is the user-message body (name + description +
+        # the classifier's matches at every level). Changing any of
+        # those invalidates only that entity's cached judgment.
+        requests: list[tuple[str, str]] = []
+        bundle_by_given_id: dict[str, tuple[Any, dict[str, Any]]] = {}
+        for eid, b in bundles.items():
+            user_text = build_user_prompt(b["name"], b["description"],
+                                          b["matches"], config)
+            given_id = str(eid)
+            requests.append((given_id, user_text))
+            bundle_by_given_id[given_id] = (eid, b)
+
+        responses = cache.bulk_get_cache_or_run(
+            given_ids_texts=requests,
+            max_workers=workers,
+            read_from_cache=read_from_cache,
+            write_to_cache=write_to_cache,
+        )
+        session.commit()
 
         all_rows: list[dict[str, Any]] = []
         all_verdicts: list[dict[str, Any]] = []
-
-        if workers <= 1:
-            for i, (eid, b) in enumerate(bundles.items(), start=1):
-                display_name = str(b["name"])[:80]
-                print(f"  [{i}/{len(bundles)}] {display_name}")
-                rows, verdict = judge_entity(
-                    client, judge_model, eid, b["name"], b["description"],
-                    b["matches"], config, system_prompt,
-                )
-                all_rows.extend(rows)
-                if verdict is not None:
-                    all_verdicts.append(verdict)
-        else:
-            with ThreadPoolExecutor(max_workers=workers) as pool:
-                futures = {
-                    pool.submit(
-                        judge_entity,
-                        client, judge_model, eid, b["name"], b["description"],
-                        b["matches"], config, system_prompt,
-                    ): (eid, b["name"])
-                    for eid, b in bundles.items()
-                }
-                done = 0
-                for fut in as_completed(futures):
-                    eid, name = futures[fut]
-                    done += 1
-                    rows, verdict = fut.result()
-                    display = str(name)[:60]
-                    v_str = verdict.get("verdict") if verdict else "ERR"
-                    print(
-                        f"  [{done}/{len(futures)}] {display} -> "
-                        f"{len(rows)} scored matches, verdict={v_str}"
-                    )
-                    all_rows.extend(rows)
-                    if verdict is not None:
-                        all_verdicts.append(verdict)
+        for given_id, _ in requests:
+            eid, b = bundle_by_given_id[given_id]
+            resp = responses.get(given_id)
+            if resp is None:
+                # API failed and got recorded as an error row; no
+                # judgment available for this entity.
+                continue
+            try:
+                judgment = JudgmentResponse.model_validate_json(resp["response_text"])
+            except Exception as exc:  # noqa: BLE001
+                print(f"  [warn] bad JSON for {str(b['name'])[:60]}: {exc}")
+                continue
+            rows, verdict = _parse_judgment(
+                eid, b["name"], b["matches"], judgment, config,
+            )
+            all_rows.extend(rows)
+            if verdict is not None:
+                all_verdicts.append(verdict)
 
         scored_df = pd.DataFrame(all_rows)
         _write_table(scored_df, output_path)
@@ -969,6 +1044,11 @@ def run_judge_evaluation(
 
 __all__ = [
     "JudgeConfig",
+    "JudgeCache",
+    "JudgmentResponse",
+    "MatchScore",
+    "LevelMatches",
+    "AlignmentVerdict",
     "DEFAULT_SCORING_RUBRIC",
     "DEFAULT_STRICTNESS",
     "build_judge_system_prompt",
@@ -976,7 +1056,6 @@ __all__ = [
     "lookup_def",
     "collect_entity_matches",
     "has_any_matches",
-    "judge_entity",
     "summarize",
     "per_entity_means",
     "failure_samples",

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -150,18 +150,22 @@ for still appear with all level columns null.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any, Iterable
 
 import pandas as pd
+from pydantic import BaseModel
 
+from vdl_tools.shared_tools.openai.openai_api_utils import is_reasoning_model
 from vdl_tools.shared_tools.taxonomy_mapping.taxonomy_mapping_cache import (
     MatchesResponse,
     ScopeDecision,
     ScopeRecoveryCache,
     TaxonomyMatchCache,
 )
+from vdl_tools.shared_tools.tools.logger import logger
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +361,7 @@ def build_system_prompt(
     modes: list[dict] | None = None,
     rules: dict[str, str] | None = None,
     include_confidence: bool = False,
+    match_schema: type[BaseModel] | None = None,
 ) -> str:
     """Assemble a hierarchical-taxonomy classification system prompt.
 
@@ -388,6 +393,17 @@ def build_system_prompt(
         Optional dict mapping any of the keys in ``PROMPT_RULE_KEYS``
         to a full override body (without leading number). Missing
         keys fall back to ``_default_rule_bodies(levels)``.
+    match_schema
+        Optional Pydantic class describing the per-match shape. When
+        provided, its JSON schema is rendered into the prompt in place
+        of the hardcoded shape. **Pass the same class to
+        ``classify_entities(match_schema=...)``** so the prompt and the
+        structural enforcement at the API layer match — otherwise the
+        model is forced (under OpenAI strict mode) to emit fields the
+        prompt doesn't describe. The ``modes`` / ``include_confidence``
+        flags still control the prose explanatory sections; the caller
+        is responsible for keeping the schema's fields in sync with
+        those flags.
     """
     overrides = rules or {}
 
@@ -399,8 +415,15 @@ def build_system_prompt(
     # genuine bidirectional precision/recall knob.
     conf_field = '"confidence": <number 0-1>, ' if include_confidence else ''
 
-    # JSON output schema — mode_of_operation included only when modes given.
-    if modes:
+    # JSON output schema.
+    # When ``match_schema`` is supplied, render its JSON schema literally
+    # so the prompt prose matches the strict-mode enforcement the API
+    # layer will apply. Otherwise fall back to the hardcoded shape
+    # (legacy callers that haven't moved to per-project schemas yet).
+    if match_schema is not None:
+        rendered = json.dumps(match_schema.model_json_schema(), indent=2)
+        schema = "  " + rendered.replace("\n", "\n  ")
+    elif modes:
         mode_union = " | ".join(f'"{m["name"]}"' for m in modes)
         schema = (
             '  {"matches": [{"index": <int>, '
@@ -534,6 +557,13 @@ def _clean_matches(
     indices, duplicates, and (when set) matches below
     ``confidence_threshold``. Returns dicts shaped like the legacy
     ``call_openai_match`` output so the rest of the walk is unchanged.
+
+    Uses ``getattr`` for ``mode_of_operation`` / ``confidence`` so this
+    works whether the driver's ``match_schema`` includes those fields
+    or not. A schema without ``mode_of_operation`` yields ``mode=""``,
+    which means the indirect-fanout-stop can never fire for that
+    driver — matching the legacy behavior of prompts built without
+    ``modes=``.
     """
     n = len(candidates)
     cleaned: list[dict[str, Any]] = []
@@ -543,17 +573,17 @@ def _clean_matches(
         if idx == 0:
             continue
         if not (1 <= idx <= n):
-            print(f"  [warn] out-of-range index at {level_name}: {idx} (n={n})")
+            logger.warning(f"  [warn] out-of-range index at {level_name}: {idx} (n={n})")
             continue
         if idx in seen:
             continue
         seen.add(idx)
         name = str(candidates.iloc[idx - 1][key_col])
-        mode = (m.mode_of_operation or "").strip().lower()
+        mode = (getattr(m, "mode_of_operation", None) or "").strip().lower()
         if mode and mode not in {"direct", "enabling tech", "indirect"}:
-            print(f"  [warn] unexpected mode_of_operation at {level_name}: {mode!r}")
+            logger.warning(f"  [warn] unexpected mode_of_operation at {level_name}: {mode!r}")
             mode = ""
-        confidence = m.confidence
+        confidence = getattr(m, "confidence", None)
         if confidence is not None:
             try:
                 confidence = max(0.0, min(1.0, float(confidence)))
@@ -645,6 +675,8 @@ def classify_entities(
     seed_col: str | None = None,
     read_from_cache: bool = True,
     write_to_cache: bool = True,
+    match_schema: type[BaseModel] | None = None,
+    temperature: float | None = 0,
 ) -> pd.DataFrame:
     """Classify many entities against the taxonomy via a SQL-cached walk.
 
@@ -716,6 +748,22 @@ def classify_entities(
         When False, leave the cache untouched (read-only / passthrough).
         Also gated by the cache's constructor-level ``store_results``.
         Default True.
+    match_schema
+        Optional Pydantic class for the per-match response shape. When
+        provided, drives both the cache's structured-output constraint
+        (via ``TaxonomyMatchCache(response_model=...)``) AND the response
+        parsing here. **Pass the same class to ``build_system_prompt(
+        match_schema=...)``** so the prompt prose matches the strict-mode
+        enforcement; otherwise the model is forced to emit fields the
+        prompt didn't describe. When ``None``, the default
+        ``MatchesResponse`` is used — permissive (mode + confidence
+        nullable) for backward compatibility.
+    temperature
+        Sampling temperature for the model. Defaults to ``0`` to match
+        the legacy ``call_openai_match`` path (deterministic outputs).
+        Automatically suppressed for reasoning models (``gpt-5*``),
+        which reject the parameter — those models use their own
+        sampling internally. Pass ``None`` to omit entirely.
     """
     levels = normalize_levels(levels)
     last_idx = levels[-1]["idx"]
@@ -723,14 +771,22 @@ def classify_entities(
     leaf_keys = ["deepest_match", "leaf_definition", "mode_of_operation",
                  "evidence", "reason", "confidence"]
     empty_leaf = {k: None for k in leaf_keys}
+    response_model: type[BaseModel] = match_schema or MatchesResponse
 
-    print(f"Classifying {len(entities)} entities (cached, level-batched)")
+    # Reasoning models reject `temperature`; suppress it for them.
+    # Otherwise default to 0 (legacy behavior, deterministic outputs).
+    api_kwargs: dict[str, Any] = {}
+    if temperature is not None and not is_reasoning_model(model):
+        api_kwargs["temperature"] = temperature
+
+    logger.info(f"Classifying {len(entities)} entities (cached, level-batched)")
     t0 = time.time()
 
     cache = TaxonomyMatchCache(
         session=session,
         system_prompt=system_prompt,
         model=model,
+        response_model=response_model,
     )
 
     # Initialize one branch per entity. Carry each input row's columns
@@ -797,12 +853,13 @@ def classify_entities(
 
         # Phase B — one bulk call for this level.
         if requests:
-            print(f"  [{lvl['name']}] {len(requests)} request(s)")
+            logger.info(f"  [{lvl['name']}] {len(requests)} request(s)")
             responses = cache.bulk_get_cache_or_run(
                 given_ids_texts=[(gid, txt) for gid, txt, _, _ in requests],
                 read_from_cache=read_from_cache,
                 write_to_cache=write_to_cache,
                 max_workers=max_workers,
+                **api_kwargs,
             )
 
             # Phase C — parse responses; spawn child branches with the
@@ -817,9 +874,9 @@ def classify_entities(
                         leaves.append(branch)
                     continue
                 try:
-                    parsed = MatchesResponse.model_validate_json(resp["response_text"])
+                    parsed = response_model.model_validate_json(resp["response_text"])
                 except Exception as exc:  # noqa: BLE001
-                    print(f"  [warn] bad response at {lvl['name']} "
+                    logger.warning(f"  [warn] bad response at {lvl['name']} "
                           f"for {branch['entity_id']}: {exc}")
                     if branch["leaf"] is not empty_leaf:
                         leaves.append(branch)
@@ -925,7 +982,7 @@ def classify_entities(
                 empty[f"{oc} confidence"] = None
         all_records.append({**base, **empty})
 
-    print(f"\nTotal elapsed: {time.time() - t0:.1f}s")
+    logger.info(f"\nTotal elapsed: {time.time() - t0:.1f}s")
 
     front = [id_col, name_col, text_col]
     extras = [c for c in entities.columns if c not in front]
@@ -1081,6 +1138,7 @@ def recover_unmatched(
     max_workers: int = 8,
     read_from_cache: bool = True,
     write_to_cache: bool = True,
+    temperature: float | None = 0,
 ) -> pd.DataFrame:
     """Second-stage scope check on entities the walk left unmatched.
 
@@ -1141,7 +1199,7 @@ def recover_unmatched(
 
     results: dict[Any, tuple] = {}
     if unmatched_ids:
-        print(f"Recovering {len(unmatched_ids)} unmatched entities with {model}")
+        logger.info(f"Recovering {len(unmatched_ids)} unmatched entities with {model}")
         rep = (df[df[id_col].isin(unmatched_ids)]
                .drop_duplicates(id_col).set_index(id_col))
 
@@ -1160,11 +1218,16 @@ def recover_unmatched(
             requests.append((str(uid), user_text))
             uid_by_str[str(uid)] = uid
 
+        api_kwargs: dict[str, Any] = {}
+        if temperature is not None and not is_reasoning_model(model):
+            api_kwargs["temperature"] = temperature
+
         responses = cache.bulk_get_cache_or_run(
             given_ids_texts=requests,
             read_from_cache=read_from_cache,
             write_to_cache=write_to_cache,
             max_workers=max_workers,
+            **api_kwargs,
         )
 
         for str_uid, user_text in requests:

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -3,8 +3,8 @@ Hierarchical Taxonomy Mapping — general library
 ================================================
 
 Reusable utilities for matching a list of entities (companies/organizations)
-against a multi-level hierarchical taxonomy via an OpenAI chat-completion
-model.
+against a multi-level hierarchical taxonomy via an OpenAI model, with all
+calls routed through the project's SQL prompt/response cache.
 
 Algorithm
 ---------
@@ -29,9 +29,30 @@ This module is taxonomy-agnostic. Callers (driver scripts) supply:
     * a system prompt string describing the matching task — assemble one
       with ``build_system_prompt`` (see "System prompt" below),
     * a taxonomy xlsx whose sheet names align with the level spec,
-    * an entities DataFrame with id / name / text columns.
+    * an entities DataFrame with id / name / text columns,
+    * a SQLAlchemy session for the prompt/response cache (see "Caching").
 
-See ``drawdown_hierarchical_taxonomy_mapping.py`` for an example driver.
+See ``oe_hierarchical_taxonomy_mapping.py`` for an example driver.
+
+Caching
+-------
+Every OpenAI call goes through ``TaxonomyMatchCache`` /
+``ScopeRecoveryCache`` (in ``taxonomy_mapping_cache.py``), which extend
+``PromptResponseCacheSQL``. Cache rows are keyed by
+``(prompt_id, given_id, text_id)``:
+
+    * ``prompt_id`` — hash of the system prompt + the Pydantic response
+      schema, so changing either invalidates all rows for the next run.
+    * ``given_id`` — built per-call from
+      ``f"{entity_id}|{level_name}|{sorted parent_path}"``; stable across
+      re-runs.
+    * ``text_id`` — hash of the user-message body (entity name +
+      description + level name + rendered candidate list); changing a
+      candidate's definition invalidates only the branches that saw it.
+
+The engine batches one ``bulk_get_cache_or_run`` per level — concurrency
+comes from the cache's worker pool (bounded by ``max_workers``), and the
+session is touched only on the main thread between batches.
 
 Level Spec
 ----------
@@ -118,10 +139,10 @@ Output schema
     + [other entity columns, in input order]
     + [lvl["output_col"] for lvl in levels]
     + ["deepest_match", "leaf_definition",
-       "mode_of_operation", "evidence", "reason"]
+       "mode_of_operation", "evidence", "reason", "confidence"]
 
-One row per (entity, leaf) pair. Entities with no level-0 match still
-appear with all level columns null.
+One row per (entity, leaf) pair. Entities the walk never produced a leaf
+for still appear with all level columns null.
 
 ``collapse_to_one_row_per_uid`` collapses that frame to one row per
 ``id_col`` value with ``repr()``-encoded list cells per level.
@@ -129,42 +150,18 @@ appear with all level columns null.
 
 from __future__ import annotations
 
-import configparser
-import json
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Iterable
 
 import pandas as pd
-from openai import OpenAI
 
-
-# ---------------------------------------------------------------------------
-# OpenAI client
-# ---------------------------------------------------------------------------
-
-def build_openai_client(
-    config_paths: Path | Iterable[Path],
-) -> OpenAI:
-    """Read the API key from the first config.ini that exists; return a client.
-
-    ``config_paths`` may be a single Path or an iterable of Paths. The
-    function tries each in order, returning a client built from the first
-    one that exists and contains an ``[openai]`` section.
-    """
-    if isinstance(config_paths, Path):
-        config_paths = [config_paths]
-    cfg = configparser.ConfigParser()
-    for candidate in config_paths:
-        if candidate.exists():
-            cfg.read(candidate)
-            if cfg.has_section("openai"):
-                return OpenAI(api_key=cfg["openai"]["openai_api_key"])
-    raise RuntimeError(
-        f"Could not find an [openai] section in any of: "
-        f"{[str(p) for p in config_paths]}"
-    )
+from vdl_tools.shared_tools.taxonomy_mapping.taxonomy_mapping_cache import (
+    MatchesResponse,
+    ScopeDecision,
+    ScopeRecoveryCache,
+    TaxonomyMatchCache,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -479,28 +476,24 @@ def format_candidates(candidates: pd.DataFrame, key_col: str) -> str:
     return "\n\n".join(lines)
 
 
-def call_openai_match(
-    client: OpenAI,
-    system_prompt: str,
-    model: str,
+# ---------------------------------------------------------------------------
+# Per-level request building + match parsing
+# ---------------------------------------------------------------------------
+
+def _build_user_text(
     entity_name: str,
     entity_description: str,
     level_name: str,
     candidates: pd.DataFrame,
     key_col: str,
-    confidence_threshold: float | None = None,
-) -> list[dict[str, str]]:
-    """Ask the model for the best candidate match(es) at this level.
+) -> str:
+    """User-message body for a single per-level match call.
 
-    When ``confidence_threshold`` is set, the system prompt is expected to
-    request a per-match ``confidence`` (build it with
-    ``build_system_prompt(include_confidence=True)``); matches whose
-    confidence is below the threshold are dropped. The threshold is the
-    precision/recall knob: lower keeps more (weak) matches, higher keeps
-    only strong ones. Missing/unparseable confidence defaults to 1.0 so a
-    non-confidence prompt behaves exactly as before.
+    The body is the cache's ``text`` input — its hash becomes the cache
+    row's ``text_id``. Changing any candidate's name or definition
+    therefore invalidates only the rows that saw that candidate list.
     """
-    user_prompt = (
+    return (
         f"Entity name: {entity_name}\n\n"
         f"Entity description:\n{entity_description}\n\n"
         f"Taxonomy level: {level_name}\n"
@@ -508,37 +501,45 @@ def call_openai_match(
         f"{format_candidates(candidates, key_col)}"
     )
 
-    resp = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
-        response_format={"type": "json_object"},
-        temperature=0,
-    )
 
-    raw = resp.choices[0].message.content or "{}"
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        print(f"  [warn] bad JSON at level {level_name}: {raw[:200]}")
-        return []
+def _build_given_id(
+    entity_id: Any,
+    parent_path: dict[str, Any],
+    level_name: str,
+) -> str:
+    """Stable cache ``given_id`` for one (entity, parent_path, level) call.
 
-    matches = data.get("matches", []) or []
+    Parent-path entries are alphabetized so dict iteration order can't
+    perturb the hash across runs. ``|`` and ``>`` are safe separators —
+    taxonomy level / column names use spaces, hyphens, and parentheses
+    but neither of these characters.
+    """
+    if parent_path:
+        path = ">".join(f"{k}={v}" for k, v in sorted(parent_path.items()))
+    else:
+        path = ""
+    return f"{entity_id}|{level_name}|{path}"
+
+
+def _clean_matches(
+    matches: list[Any],
+    candidates: pd.DataFrame,
+    key_col: str,
+    level_name: str,
+    confidence_threshold: float | None,
+) -> list[dict[str, Any]]:
+    """Validate parsed ``Match`` objects against the candidate list.
+
+    Drops idx==0 (no-match sentinel some models still emit), out-of-range
+    indices, duplicates, and (when set) matches below
+    ``confidence_threshold``. Returns dicts shaped like the legacy
+    ``call_openai_match`` output so the rest of the walk is unchanged.
+    """
     n = len(candidates)
-    cleaned: list[dict[str, str]] = []
+    cleaned: list[dict[str, Any]] = []
     seen: set[int] = set()
     for m in matches:
-        raw_idx = m.get("index")
-        try:
-            idx = int(raw_idx)
-        except (TypeError, ValueError):
-            print(f"  [warn] non-integer index at {level_name}: {raw_idx!r}")
-            continue
-        # Candidate list is rendered 1-based; convert to a 0-based row index.
-        # The prompt says to return `matches: []` for "no match", but some
-        # models still emit index 0 as a no-match signal — accept it silently.
+        idx = m.index
         if idx == 0:
             continue
         if not (1 <= idx <= n):
@@ -548,22 +549,14 @@ def call_openai_match(
             continue
         seen.add(idx)
         name = str(candidates.iloc[idx - 1][key_col])
-        mode = str(m.get("mode_of_operation", "")).strip().lower()
-        # Empty / unrecognized modes are normalized to "" so downstream
-        # rules (e.g. the indirect-fanout stop) can compare safely.
+        mode = (m.mode_of_operation or "").strip().lower()
         if mode and mode not in {"direct", "enabling tech", "indirect"}:
             print(f"  [warn] unexpected mode_of_operation at {level_name}: {mode!r}")
             mode = ""
-        # Confidence: parse to float in [0,1] when present, else None (so a
-        # non-confidence prompt leaves the field blank rather than implying
-        # a score). A missing/unparseable confidence never filters — only an
-        # explicit below-threshold value drops the match.
-        raw_conf = m.get("confidence")
-        if raw_conf is None:
-            confidence = None
-        else:
+        confidence = m.confidence
+        if confidence is not None:
             try:
-                confidence = max(0.0, min(1.0, float(raw_conf)))
+                confidence = max(0.0, min(1.0, float(confidence)))
             except (TypeError, ValueError):
                 confidence = None
         if (confidence_threshold is not None and confidence is not None
@@ -572,289 +565,71 @@ def call_openai_match(
         cleaned.append({
             "name": name,
             "mode_of_operation": mode,
-            "evidence": str(m.get("evidence", "")).strip(),
-            "reason": str(m.get("reason", "")).strip(),
+            "evidence": (m.evidence or "").strip(),
+            "reason": (m.reason or "").strip(),
             "confidence": confidence,
         })
     return cleaned
 
 
-# ---------------------------------------------------------------------------
-# Hierarchical walk
-# ---------------------------------------------------------------------------
-
-def classify_entity(
-    client: OpenAI,
-    tables: dict[int, pd.DataFrame],
-    levels: list[dict],
-    system_prompt: str,
-    entity_name: str,
-    entity_description: str,
-    model: str,
-    descent_fanout_cap: int,
-    confidence_threshold: float | None = None,
-    emit_per_level: bool = False,
-    seed_names: dict[str, str] | None = None,
-) -> list[dict[str, Any]]:
-    """Walk the taxonomy top-down for a single entity.
-
-    ``seed_names`` fixes a contiguous top prefix of the levels (mapping each
-    seeded level's ``output_col`` to its value, e.g. ``{"Pillar": "Energy
-    Transition"}``) and the walk descends only the remaining levels from
-    that seeded parent — used to continue into a subtree after a top-level
-    node has been assigned elsewhere (e.g. by the empties recovery). The
-    seeded levels carry no evidence/reason of their own.
-
-    Returns one record per LEAF in the match tree — i.e. per root-to-tip
-    path through the accepted matches. A leaf is a match that was either
-    (a) at the deepest level, (b) had no children matched, (c) truncated
-    by the descent fan-out cap, or (d) tagged ``indirect`` by the prompt
-    when there were multiple sibling matches at the same step (the
-    "indirect-fanout stop"; a no-op when the prompt does not return a
-    ``mode_of_operation`` field).
-
-    Each record has one column per level (named by ``output_col``, empty
-    where the branch stopped early) plus the leaf's level name in
-    ``deepest_match``, plus its definition, mode, evidence, and reason.
-    """
-    empty_leaf = {
-        "deepest_match": None,
-        "leaf_definition": None,
-        "mode_of_operation": None,
-        "evidence": None,
-        "reason": None,
-        "confidence": None,
-    }
-    last_idx = levels[-1]["idx"]
-
-    # path_meta: out_col -> {evidence, reason, confidence, mode} for every
-    # level matched along this path, for the per-level output (emit_per_level).
-    if seed_names:
-        # Reconstruct the seeded prefix's names + parent_path so the walk can
-        # descend its children. Stops seeding at the first level whose value
-        # is missing or not found (then walks normally from there).
-        names: dict[str, Any] = {}
-        parent_path: dict[str, Any] = {}
-        seed_leaf = empty_leaf
-        start_idx = 0
-        for lvl in levels:
-            oc = lvl["output_col"]
-            if oc not in seed_names:
-                break
-            cands = candidates_for_level(tables, lvl["idx"], parent_path)
-            match = cands[cands[lvl["key_col"]] == seed_names[oc]]
-            if match.empty:
-                break
-            row = match.iloc[0]
-            names[oc] = seed_names[oc]
-            if lvl["idx"] != last_idx:
-                parent_path[lvl["child_filter_col"]] = row[lvl["child_filter_value_col"]]
-            seed_leaf = {
-                "deepest_match": lvl["name"],
-                "leaf_definition": str(row["Definition"]).strip(),
-                "mode_of_operation": None,
-                "evidence": None,
-                "reason": None,
-                "confidence": None,
-            }
-            start_idx = lvl["idx"] + 1
-        initial_branch = {"names": names, "parent_path": parent_path,
-                          "leaf": seed_leaf, "path_meta": {}}
-        levels_to_walk = [lvl for lvl in levels if lvl["idx"] >= start_idx]
-    else:
-        initial_branch = {
-            "names": {}, "parent_path": {}, "leaf": empty_leaf, "path_meta": {},
-        }
-        levels_to_walk = levels
-
-    active: list[dict[str, Any]] = [initial_branch]
-    leaves: list[dict[str, Any]] = []
-
-    for lvl in levels_to_walk:
-        level_idx = lvl["idx"]
-        key_col = lvl["key_col"]
-        out_col = lvl["output_col"]
-        is_last_level = level_idx == last_idx
-        if not is_last_level:
-            child_filter_col = lvl["child_filter_col"]
-            child_filter_value_col = lvl["child_filter_value_col"]
-
-        next_active: list[dict[str, Any]] = []
-
-        for branch in active:
-            candidates = candidates_for_level(tables, level_idx, branch["parent_path"])
-            if candidates.empty:
-                if branch["leaf"] is not empty_leaf:
-                    leaves.append(branch)
-                continue
-
-            matches = call_openai_match(
-                client=client,
-                system_prompt=system_prompt,
-                model=model,
-                entity_name=entity_name,
-                entity_description=entity_description,
-                level_name=lvl["name"],
-                candidates=candidates,
-                key_col=key_col,
-                confidence_threshold=confidence_threshold,
-            )
-
-            if not matches:
-                if branch["leaf"] is not empty_leaf:
-                    leaves.append(branch)
-                continue
-
-            for i, m in enumerate(matches):
-                cand_row = candidates[candidates[key_col] == m["name"]].iloc[0]
-                new_names = dict(branch["names"])
-                new_names[out_col] = m["name"]
-                new_parent_path = dict(branch["parent_path"])
-                if not is_last_level:
-                    new_parent_path[child_filter_col] = cand_row[child_filter_value_col]
-                new_leaf = {
-                    "deepest_match": lvl["name"],
-                    "leaf_definition": str(cand_row["Definition"]).strip(),
-                    "mode_of_operation": m["mode_of_operation"],
-                    "evidence": m["evidence"],
-                    "reason": m["reason"],
-                    "confidence": m.get("confidence"),
-                }
-                new_path_meta = dict(branch["path_meta"])
-                new_path_meta[out_col] = {
-                    "evidence": m["evidence"],
-                    "reason": m["reason"],
-                    "confidence": m.get("confidence"),
-                    "mode_of_operation": m["mode_of_operation"],
-                }
-                new_branch = {
-                    "names": new_names,
-                    "parent_path": new_parent_path,
-                    "leaf": new_leaf,
-                    "path_meta": new_path_meta,
-                }
-                # Indirect-fanout stop: an `indirect` (advocacy / policy /
-                # education) match descends only when it is the SOLE match
-                # at this step. Multiple indirect siblings indicate the
-                # entity advocates broadly across the level and naming any
-                # specific child would be guesswork; record them as final
-                # leaves at the current level instead. Direct / enabling-
-                # tech matches still descend normally (subject to the
-                # fan-out cap).
-                indirect_fanout = (
-                    m["mode_of_operation"] == "indirect"
-                    and len(matches) > 1
-                )
-                if is_last_level or i >= descent_fanout_cap or indirect_fanout:
-                    leaves.append(new_branch)
-                else:
-                    next_active.append(new_branch)
-
-        active = next_active
-        if not active:
-            break
-
-    leaves.extend(active)
-
-    out_cols = [lvl["output_col"] for lvl in levels]
-
-    def _record(b: dict[str, Any]) -> dict[str, Any]:
-        rec = {c: b["names"].get(c) for c in out_cols}
-        rec.update(b["leaf"])
-        if emit_per_level:
-            # Per-level evidence / reason / confidence for every level matched
-            # on this path (None where the branch stopped short). Columns are
-            # named "<output_col> evidence" etc.
-            for oc in out_cols:
-                pm = b["path_meta"].get(oc, {})
-                rec[f"{oc} evidence"] = pm.get("evidence")
-                rec[f"{oc} reason"] = pm.get("reason")
-                rec[f"{oc} confidence"] = pm.get("confidence")
-        return rec
-
-    return [_record(b) for b in leaves]
-
-
-# ---------------------------------------------------------------------------
-# Per-entity worker
-# ---------------------------------------------------------------------------
-
-def _classify_one(
-    client: OpenAI,
-    tables: dict[int, pd.DataFrame],
-    levels: list[dict],
-    system_prompt: str,
+def _seed_branch(
     row: pd.Series,
-    id_col: str,
-    name_col: str,
-    text_col: str,
-    model: str,
-    descent_fanout_cap: int,
-    confidence_threshold: float | None = None,
-    emit_per_level: bool = False,
-    seed_col: str | None = None,
-) -> list[dict[str, Any]]:
-    """Classify a single entity and return flat output rows.
+    levels: list[dict],
+    tables: dict[int, pd.DataFrame],
+    seed_col: str | None,
+    empty_leaf: dict[str, Any],
+    last_idx: int,
+) -> tuple[dict[str, Any], dict[str, Any], int, dict[str, Any]]:
+    """Compute (names, parent_path, start_idx, seed_leaf) for an entity.
 
-    All columns of ``row`` are carried through into ``base`` so the
-    per-row output keeps any extra attributes (Funding, x/y, etc.).
-    Emits one null-taxonomy row when there is no level-0 match so the
-    entity still appears in the output. When ``seed_col`` is set and the
-    row has a non-empty value there, the walk is seeded at the top level
-    with that value (see ``classify_entity``'s ``seed_names``).
+    With no seeding (no ``seed_col`` or a blank value), returns
+    ``({}, {}, 0, empty_leaf)`` — equivalent to walking from the root.
+    Otherwise reconstructs the seeded prefix's ``names`` and
+    ``parent_path`` so the level loop can descend the seeded subtree
+    starting at ``start_idx``.
     """
-    name = str(row[name_col])
-    desc = str(row[text_col])
-    base = {col: row[col] for col in row.index}
-    base[name_col] = name
-    base[text_col] = desc
+    if seed_col is None:
+        return {}, {}, 0, empty_leaf
+    seed_val = row.get(seed_col)
+    if seed_val is None or str(seed_val).strip() in ("", "nan", "None"):
+        return {}, {}, 0, empty_leaf
 
-    seed_names = None
-    if seed_col is not None:
-        seed_val = row.get(seed_col)
-        if seed_val is not None and str(seed_val).strip() not in ("", "nan", "None"):
-            seed_names = {levels[0]["output_col"]: str(seed_val)}
-
-    try:
-        records = classify_entity(
-            client=client,
-            tables=tables,
-            levels=levels,
-            system_prompt=system_prompt,
-            entity_name=name,
-            entity_description=desc,
-            model=model,
-            descent_fanout_cap=descent_fanout_cap,
-            confidence_threshold=confidence_threshold,
-            emit_per_level=emit_per_level,
-            seed_names=seed_names,
-        )
-    except Exception as exc:  # noqa: BLE001
-        print(f"  [error] {name}: {exc}")
-        return []
-
-    leaf_keys = ["deepest_match", "leaf_definition",
-                 "mode_of_operation", "evidence", "reason", "confidence"]
-    if not records:
-        empty = {lvl["output_col"]: None for lvl in levels}
-        empty.update({k: None for k in leaf_keys})
-        if emit_per_level:
-            for lvl in levels:
-                oc = lvl["output_col"]
-                empty[f"{oc} evidence"] = None
-                empty[f"{oc} reason"] = None
-                empty[f"{oc} confidence"] = None
-        return [{**base, **empty}]
-    return [{**base, **r} for r in records]
+    seed_names = {levels[0]["output_col"]: str(seed_val)}
+    names: dict[str, Any] = {}
+    parent_path: dict[str, Any] = {}
+    seed_leaf = empty_leaf
+    start_idx = 0
+    for lvl in levels:
+        oc = lvl["output_col"]
+        if oc not in seed_names:
+            break
+        cands = candidates_for_level(tables, lvl["idx"], parent_path)
+        match = cands[cands[lvl["key_col"]] == seed_names[oc]]
+        if match.empty:
+            break
+        cand_row = match.iloc[0]
+        names[oc] = seed_names[oc]
+        if lvl["idx"] != last_idx:
+            parent_path[lvl["child_filter_col"]] = cand_row[lvl["child_filter_value_col"]]
+        seed_leaf = {
+            "deepest_match": lvl["name"],
+            "leaf_definition": str(cand_row["Definition"]).strip(),
+            "mode_of_operation": None,
+            "evidence": None,
+            "reason": None,
+            "confidence": None,
+        }
+        start_idx = lvl["idx"] + 1
+    return names, parent_path, start_idx, seed_leaf
 
 
 # ---------------------------------------------------------------------------
-# Batch entry point
+# Batch entry point — bulk-per-level walk against the SQL cache
 # ---------------------------------------------------------------------------
 
 def classify_entities(
     *,
-    client: OpenAI,
+    session,
     tables: dict[int, pd.DataFrame],
     levels: list[dict],
     system_prompt: str,
@@ -868,78 +643,294 @@ def classify_entities(
     confidence_threshold: float | None = None,
     emit_per_level: bool = False,
     seed_col: str | None = None,
+    use_cached_result: bool = True,
 ) -> pd.DataFrame:
-    """Classify many entities in parallel; return one flat DataFrame.
+    """Classify many entities against the taxonomy via a SQL-cached walk.
 
-    When ``seed_col`` is set, each entity whose ``seed_col`` value is
-    non-empty has its walk seeded at the top level with that value (the
-    walk descends that node's subtree); entities with an empty seed walk
-    from the root as usual. Useful for descending into a subtree after a
-    top-level assignment from elsewhere (e.g. the empties recovery).
+    Walks the taxonomy level-by-level. At each level, every active
+    branch's OpenAI call is batched into a single
+    ``bulk_get_cache_or_run`` so cache hits skip the API entirely and
+    fresh calls are parallelized inside the cache. The SQLAlchemy
+    ``session`` is touched only on the main thread between batches —
+    workers do API I/O only.
 
-    ``entities`` must have at least ``id_col``, ``name_col``, ``text_col``.
-    The output has those columns followed by every other entity column
-    (in input order), then one column per level (``output_col``), then
-    five leaf columns: ``deepest_match``, ``leaf_definition``,
-    ``mode_of_operation``, ``evidence``, ``reason``.
+    Cache keys:
+        prompt_id = hash(system_prompt + MatchesResponse schema)
+        given_id  = "<entity_id>|<level_name>|<sorted parent_path>"
+        text_id   = hash(entity_name + description + level_name + candidates)
 
-    Uses a thread pool because each entity's hierarchical walk is
-    independent and the work is I/O-bound on the OpenAI API.
+    Re-running the same pipeline against the same taxonomy + system
+    prompt is a no-API run after the first successful pass; changing
+    the taxonomy xlsx invalidates only the affected branches; changing
+    the system prompt invalidates everything.
+
+    Parameters
+    ----------
+    session
+        SQLAlchemy session used by the cache. Build via
+        ``vdl_tools.shared_tools.database_cache.database_utils.get_session``;
+        the caller's ``with get_session() as session:`` block scopes the
+        transaction. The cache commits per-chunk; this function also
+        commits once at the end so a caller using a short-lived session
+        does not lose the last batch.
+    tables
+        Per-level taxonomy DataFrames keyed by level index.
+    levels
+        Level spec — see module docstring.
+    system_prompt
+        System prompt for every match call. Build via
+        ``build_system_prompt`` (or a thin wrapper).
+    entities
+        Entities to classify. Must contain ``id_col``, ``name_col``,
+        ``text_col``; any other columns are carried through to the
+        per-row output untouched.
+    id_col, name_col, text_col
+        Column names on ``entities``.
+    model
+        OpenAI model id (e.g. ``"gpt-4.1"``, ``"gpt-5-nano"``). Routed
+        through ``InstructorPRC.get_completion`` -> Responses API; the
+        cache scopes by model name only when constructed with
+        ``filter_by_model=True`` (not the default — share cache rows
+        across models for the same prompt + text).
+    descent_fanout_cap
+        Maximum number of children to descend into when a level returns
+        multiple matches.
+    max_workers
+        Concurrency cap for the cache's API worker pool, applied per
+        level batch.
+    confidence_threshold
+        Drop matches whose confidence is below this. Requires the
+        system_prompt to have been built with ``include_confidence=True``.
+    emit_per_level
+        When True, output gains ``<level> evidence / reason / confidence``
+        columns for every level matched along the path.
+    seed_col
+        Optional input column whose value pre-seeds the walk at the
+        top level (the walk descends that node's subtree). Used by the
+        recovery flow to second-walk entities the first pass left empty.
+    use_cached_result
+        When False, bypass cached rows and re-issue the API call; the
+        new response overwrites the cache entry.
     """
     levels = normalize_levels(levels)
+    last_idx = levels[-1]["idx"]
+    out_cols = [lvl["output_col"] for lvl in levels]
+    leaf_keys = ["deepest_match", "leaf_definition", "mode_of_operation",
+                 "evidence", "reason", "confidence"]
+    empty_leaf = {k: None for k in leaf_keys}
 
-    print(
-        f"Classifying {len(entities)} entities "
-        f"with {max_workers} worker(s)"
-    )
-
-    all_records: list[dict[str, Any]] = []
+    print(f"Classifying {len(entities)} entities (cached, level-batched)")
     t0 = time.time()
 
-    if max_workers <= 1:
-        # Single-threaded path — kept unthreaded to make debugging easier.
-        for i, row in entities.iterrows():
-            print(f"[{i + 1}/{len(entities)}] {row[name_col]}")
-            all_records.extend(_classify_one(
-                client, tables, levels, system_prompt, row,
-                id_col, name_col, text_col, model, descent_fanout_cap,
-                confidence_threshold, emit_per_level, seed_col,
-            ))
-    else:
-        with ThreadPoolExecutor(max_workers=max_workers) as pool:
-            futures = {
-                pool.submit(
-                    _classify_one,
-                    client, tables, levels, system_prompt, row,
-                    id_col, name_col, text_col, model, descent_fanout_cap,
-                    confidence_threshold, emit_per_level, seed_col,
-                ): row
-                for _, row in entities.iterrows()
-            }
-            done = 0
-            for fut in as_completed(futures):
-                row = futures[fut]
-                done += 1
-                recs = fut.result()
-                print(f"[{done}/{len(entities)}] {row[name_col]} -> {len(recs)} rows")
-                all_records.extend(recs)
+    cache = TaxonomyMatchCache(
+        session=session,
+        system_prompt=system_prompt,
+        model=model,
+    )
+
+    # Initialize one branch per entity. Carry each input row's columns
+    # into base_by_entity_id so the per-row output keeps all input
+    # attributes (Funding, x/y, etc.).
+    initial_branches: list[dict[str, Any]] = []
+    base_by_entity_id: dict[Any, dict[str, Any]] = {}
+    for _, row in entities.iterrows():
+        entity_id = row[id_col]
+        name = str(row[name_col])
+        desc = str(row[text_col])
+        base = {col: row[col] for col in row.index}
+        base[name_col] = name
+        base[text_col] = desc
+        base_by_entity_id[entity_id] = base
+
+        names, parent_path, start_idx, seed_leaf = _seed_branch(
+            row, levels, tables, seed_col, empty_leaf, last_idx,
+        )
+        initial_branches.append({
+            "entity_id": entity_id,
+            "entity_name": name,
+            "entity_description": desc,
+            "names": names,
+            "parent_path": parent_path,
+            "leaf": seed_leaf,
+            "path_meta": {},
+            "start_idx": start_idx,
+        })
+
+    active = initial_branches
+    leaves: list[dict[str, Any]] = []
+
+    for lvl in levels:
+        level_idx = lvl["idx"]
+        key_col = lvl["key_col"]
+        out_col = lvl["output_col"]
+        is_last_level = level_idx == last_idx
+        if not is_last_level:
+            child_filter_col = lvl["child_filter_col"]
+            child_filter_value_col = lvl["child_filter_value_col"]
+
+        # Phase A — assemble requests; carry seeded branches forward
+        # until they reach their start_idx.
+        requests: list[tuple[str, str, dict[str, Any], pd.DataFrame]] = []
+        next_active: list[dict[str, Any]] = []
+        for branch in active:
+            if level_idx < branch["start_idx"]:
+                next_active.append(branch)
+                continue
+            candidates = candidates_for_level(tables, level_idx, branch["parent_path"])
+            if candidates.empty:
+                if branch["leaf"] is not empty_leaf:
+                    leaves.append(branch)
+                continue
+            user_text = _build_user_text(
+                branch["entity_name"], branch["entity_description"],
+                lvl["name"], candidates, key_col,
+            )
+            given_id = _build_given_id(
+                branch["entity_id"], branch["parent_path"], lvl["name"],
+            )
+            requests.append((given_id, user_text, branch, candidates))
+
+        # Phase B — one bulk call for this level.
+        if requests:
+            print(f"  [{lvl['name']}] {len(requests)} request(s)")
+            responses = cache.bulk_get_cache_or_run(
+                given_ids_texts=[(gid, txt) for gid, txt, _, _ in requests],
+                use_cached_result=use_cached_result,
+                max_workers=max_workers,
+            )
+
+            # Phase C — parse responses; spawn child branches with the
+            # same descent / fan-out / indirect-stop rules as the legacy
+            # walk.
+            for given_id, _, branch, candidates in requests:
+                resp = responses.get(given_id)
+                if resp is None:
+                    # API failed (recorded as an error row); treat as
+                    # no-match for this branch.
+                    if branch["leaf"] is not empty_leaf:
+                        leaves.append(branch)
+                    continue
+                try:
+                    parsed = MatchesResponse.model_validate_json(resp["response_text"])
+                except Exception as exc:  # noqa: BLE001
+                    print(f"  [warn] bad response at {lvl['name']} "
+                          f"for {branch['entity_id']}: {exc}")
+                    if branch["leaf"] is not empty_leaf:
+                        leaves.append(branch)
+                    continue
+
+                matches = _clean_matches(
+                    parsed.matches, candidates, key_col, lvl["name"],
+                    confidence_threshold,
+                )
+                if not matches:
+                    if branch["leaf"] is not empty_leaf:
+                        leaves.append(branch)
+                    continue
+
+                for i, m in enumerate(matches):
+                    cand_row = candidates[candidates[key_col] == m["name"]].iloc[0]
+                    new_names = dict(branch["names"])
+                    new_names[out_col] = m["name"]
+                    new_parent_path = dict(branch["parent_path"])
+                    if not is_last_level:
+                        new_parent_path[child_filter_col] = cand_row[child_filter_value_col]
+                    new_leaf = {
+                        "deepest_match": lvl["name"],
+                        "leaf_definition": str(cand_row["Definition"]).strip(),
+                        "mode_of_operation": m["mode_of_operation"],
+                        "evidence": m["evidence"],
+                        "reason": m["reason"],
+                        "confidence": m.get("confidence"),
+                    }
+                    new_path_meta = dict(branch["path_meta"])
+                    new_path_meta[out_col] = {
+                        "evidence": m["evidence"],
+                        "reason": m["reason"],
+                        "confidence": m.get("confidence"),
+                        "mode_of_operation": m["mode_of_operation"],
+                    }
+                    new_branch = {
+                        "entity_id": branch["entity_id"],
+                        "entity_name": branch["entity_name"],
+                        "entity_description": branch["entity_description"],
+                        "names": new_names,
+                        "parent_path": new_parent_path,
+                        "leaf": new_leaf,
+                        "path_meta": new_path_meta,
+                        "start_idx": branch["start_idx"],
+                    }
+                    # Indirect-fanout stop: an `indirect` (advocacy /
+                    # policy / education) match descends only when it
+                    # is the SOLE match at this step. Multiple indirect
+                    # siblings = broad advocacy; naming any specific
+                    # child would be guesswork, so record at the
+                    # current level instead.
+                    indirect_fanout = (
+                        m["mode_of_operation"] == "indirect"
+                        and len(matches) > 1
+                    )
+                    if is_last_level or i >= descent_fanout_cap or indirect_fanout:
+                        leaves.append(new_branch)
+                    else:
+                        next_active.append(new_branch)
+
+        active = next_active
+        if not active:
+            break
+
+    leaves.extend(active)
+
+    # Final commit so a caller using a short-lived session does not
+    # lose the trailing bulk-upsert chunk.
+    session.commit()
+
+    # Assemble flat per-row output.
+    def _record(b: dict[str, Any]) -> dict[str, Any]:
+        rec = {c: b["names"].get(c) for c in out_cols}
+        rec.update(b["leaf"])
+        if emit_per_level:
+            for oc in out_cols:
+                pm = b["path_meta"].get(oc, {})
+                rec[f"{oc} evidence"] = pm.get("evidence")
+                rec[f"{oc} reason"] = pm.get("reason")
+                rec[f"{oc} confidence"] = pm.get("confidence")
+        return rec
+
+    all_records: list[dict[str, Any]] = []
+    seen_entity_ids: set[Any] = set()
+    for b in leaves:
+        base = base_by_entity_id[b["entity_id"]]
+        all_records.append({**base, **_record(b)})
+        seen_entity_ids.add(b["entity_id"])
+
+    # Entities the walk never produced a leaf for still get a null
+    # taxonomy row so the caller can join on id.
+    for entity_id, base in base_by_entity_id.items():
+        if entity_id in seen_entity_ids:
+            continue
+        empty = {c: None for c in out_cols}
+        empty.update(empty_leaf)
+        if emit_per_level:
+            for lvl in levels:
+                oc = lvl["output_col"]
+                empty[f"{oc} evidence"] = None
+                empty[f"{oc} reason"] = None
+                empty[f"{oc} confidence"] = None
+        all_records.append({**base, **empty})
 
     print(f"\nTotal elapsed: {time.time() - t0:.1f}s")
 
     front = [id_col, name_col, text_col]
     extras = [c for c in entities.columns if c not in front]
-    classification_cols = (
-        [lvl["output_col"] for lvl in levels]
-        + ["deepest_match", "leaf_definition",
-           "mode_of_operation", "evidence", "reason", "confidence"]
-    )
+    classification_cols = out_cols + leaf_keys
     if emit_per_level:
         for lvl in levels:
             oc = lvl["output_col"]
             classification_cols += [f"{oc} evidence", f"{oc} reason",
                                     f"{oc} confidence"]
-    out_cols = front + extras + classification_cols
-    return pd.DataFrame(all_records, columns=out_cols)
+    out_cols_final = front + extras + classification_cols
+    return pd.DataFrame(all_records, columns=out_cols_final)
 
 
 # ---------------------------------------------------------------------------
@@ -1043,6 +1034,10 @@ def build_default_scope_prompt(
     taxonomy with no authoring, but a caller-supplied ``scope_prompt`` with
     domain-specific in/out guidance and routing will classify more
     accurately.
+
+    The recovered category is returned in the ``category`` field of the
+    ``ScopeDecision`` structured-output schema; the prompt text below
+    matches that field name.
     """
     levels = normalize_levels(levels)
     top = levels[0]
@@ -1067,7 +1062,7 @@ def build_default_scope_prompt(
 def recover_unmatched(
     df: pd.DataFrame,
     *,
-    client: OpenAI,
+    session,
     model: str,
     id_col: str,
     name_col: str,
@@ -1078,6 +1073,7 @@ def recover_unmatched(
     category_choices: Iterable[str] | None = None,
     scope_prompt: str | None = None,
     max_workers: int = 8,
+    use_cached_result: bool = True,
 ) -> pd.DataFrame:
     """Second-stage scope check on entities the walk left unmatched.
 
@@ -1090,6 +1086,10 @@ def recover_unmatched(
     top-level match, returning whether each is in scope and which
     top-level category fits.
 
+    Backed by ``ScopeRecoveryCache``: the call is keyed by the scope
+    prompt + the entity's id + a hash of the entity name+description, so
+    re-runs hit the cache for unchanged inputs.
+
     Adds three columns, filled only for unmatched entities (matched
     entities and their rows keep ``None``):
         - ``recovered_in_scope``      bool | None
@@ -1099,12 +1099,12 @@ def recover_unmatched(
     ``top_level_col``, ``category_choices``, and ``scope_prompt`` each
     default from ``levels`` + ``tables`` when omitted (top-level output
     column; top-level node names; ``build_default_scope_prompt``), so a
-    generic caller can pass just ``levels`` + ``tables``. Supply any of them
-    explicitly to override — a domain-specific ``scope_prompt`` in
-    particular classifies more accurately than the default. The scope prompt
-    must instruct the model to return JSON ``{"in_scope": bool, "<category
-    key>": "<name or null>", "reason": "..."}``; category values are
-    validated (case-insensitively) against ``category_choices``.
+    generic caller can pass just ``levels`` + ``tables``. Supply any of
+    them explicitly to override — a domain-specific ``scope_prompt`` in
+    particular classifies more accurately than the default. The scope
+    prompt must instruct the model to populate the ``category`` field of
+    the structured-output schema with the exact name of an in-scope
+    top-level node (or null); ``ScopeDecision`` is the source of truth.
     """
     if top_level_col is None or category_choices is None or scope_prompt is None:
         if levels is None or tables is None:
@@ -1131,42 +1131,54 @@ def recover_unmatched(
         uid for uid, g in df.groupby(id_col, sort=False)
         if bool(_empty(g[top_level_col]).all())
     ]
-    rep = (df[df[id_col].isin(unmatched_ids)]
-           .drop_duplicates(id_col).set_index(id_col))
-
-    cat_key = top_level_col.strip().lower()
-
-    def _recover(uid: Any) -> tuple[Any, tuple]:
-        name = str(rep.loc[uid, name_col])
-        text = str(rep.loc[uid, text_col])
-        user_prompt = f"Organization: {name}\n\nDescription:\n{text}"
-        try:
-            resp = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "system", "content": scope_prompt},
-                          {"role": "user", "content": user_prompt}],
-                response_format={"type": "json_object"}, temperature=0,
-            )
-            data = json.loads(resp.choices[0].message.content or "{}")
-            in_scope = bool(data.get("in_scope"))
-            raw_cat = data.get(cat_key) or data.get("category") or data.get("pillar")
-            cat = cats.get(str(raw_cat).strip().lower()) if raw_cat else None
-            reason = str(data.get("reason", "")).strip()
-            return uid, (in_scope, cat if in_scope else None, reason)
-        except Exception as exc:  # noqa: BLE001
-            return uid, (None, None, f"recovery error: {exc}")
 
     results: dict[Any, tuple] = {}
     if unmatched_ids:
         print(f"Recovering {len(unmatched_ids)} unmatched entities with {model}")
-        if max_workers <= 1:
-            for uid in unmatched_ids:
-                _, res = _recover(uid)
-                results[uid] = res
-        else:
-            with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                for uid, res in pool.map(_recover, unmatched_ids):
-                    results[uid] = res
+        rep = (df[df[id_col].isin(unmatched_ids)]
+               .drop_duplicates(id_col).set_index(id_col))
+
+        cache = ScopeRecoveryCache(
+            session=session,
+            scope_prompt=scope_prompt,
+            model=model,
+        )
+
+        requests: list[tuple[str, str]] = []
+        uid_by_str: dict[str, Any] = {}
+        for uid in unmatched_ids:
+            name = str(rep.loc[uid, name_col])
+            text = str(rep.loc[uid, text_col])
+            user_text = f"Organization: {name}\n\nDescription:\n{text}"
+            requests.append((str(uid), user_text))
+            uid_by_str[str(uid)] = uid
+
+        responses = cache.bulk_get_cache_or_run(
+            given_ids_texts=requests,
+            use_cached_result=use_cached_result,
+            max_workers=max_workers,
+        )
+
+        for str_uid, user_text in requests:
+            uid = uid_by_str[str_uid]
+            resp = responses.get(str_uid)
+            if resp is None:
+                results[uid] = (None, None, "recovery error: no response")
+                continue
+            try:
+                decision = ScopeDecision.model_validate_json(resp["response_text"])
+            except Exception as exc:  # noqa: BLE001
+                results[uid] = (None, None, f"recovery parse error: {exc}")
+                continue
+            cat = (cats.get(decision.category.strip().lower())
+                   if decision.category else None)
+            results[uid] = (
+                decision.in_scope,
+                cat if decision.in_scope else None,
+                decision.reason.strip(),
+            )
+
+        session.commit()
 
     df = df.copy()
     none3 = (None, None, None)

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -841,61 +841,81 @@ def classify_entities(
                         leaves.append(branch)
                     continue
 
-                matches = _clean_matches(
-                    parsed.matches, candidates, key_col, lvl["name"],
-                    confidence_threshold,
-                )
-                if not matches:
+                # Descent / fan-out. Any unexpected failure here (dtype
+                # mismatch on the candidate filter, empty `.iloc[0]`, a
+                # malformed candidate table, etc.) must NOT abort the
+                # whole batch after the paid bulk call already ran.
+                # Isolate it per branch: log and degrade to no-match,
+                # matching the legacy `_classify_one` null-row behavior.
+                # Child branches are staged locally and only committed
+                # once the whole branch succeeds, so a mid-fan-out
+                # exception cannot leave partial descendants behind.
+                try:
+                    matches = _clean_matches(
+                        parsed.matches, candidates, key_col, lvl["name"],
+                        confidence_threshold,
+                    )
+                    if not matches:
+                        if branch["leaf"] is not empty_leaf:
+                            leaves.append(branch)
+                        continue
+
+                    branch_leaves: list[dict[str, Any]] = []
+                    branch_active: list[dict[str, Any]] = []
+                    for i, m in enumerate(matches):
+                        cand_row = candidates[candidates[key_col] == m["name"]].iloc[0]
+                        new_names = dict(branch["names"])
+                        new_names[out_col] = m["name"]
+                        new_parent_path = dict(branch["parent_path"])
+                        if not is_last_level:
+                            new_parent_path[child_filter_col] = cand_row[child_filter_value_col]
+                        new_leaf = {
+                            "deepest_match": lvl["name"],
+                            "leaf_definition": str(cand_row["Definition"]).strip(),
+                            "mode_of_operation": m["mode_of_operation"],
+                            "evidence": m["evidence"],
+                            "reason": m["reason"],
+                            "confidence": m.get("confidence"),
+                        }
+                        new_path_meta = dict(branch["path_meta"])
+                        new_path_meta[out_col] = {
+                            "evidence": m["evidence"],
+                            "reason": m["reason"],
+                            "confidence": m.get("confidence"),
+                            "mode_of_operation": m["mode_of_operation"],
+                        }
+                        new_branch = {
+                            "entity_id": branch["entity_id"],
+                            "entity_name": branch["entity_name"],
+                            "entity_description": branch["entity_description"],
+                            "names": new_names,
+                            "parent_path": new_parent_path,
+                            "leaf": new_leaf,
+                            "path_meta": new_path_meta,
+                            "start_idx": branch["start_idx"],
+                        }
+                        # Indirect-fanout stop: an `indirect` (advocacy /
+                        # policy / education) match descends only when it
+                        # is the SOLE match at this step. Multiple indirect
+                        # siblings = broad advocacy; naming any specific
+                        # child would be guesswork, so record at the
+                        # current level instead.
+                        indirect_fanout = (
+                            m["mode_of_operation"] == "indirect"
+                            and len(matches) > 1
+                        )
+                        if is_last_level or i >= descent_fanout_cap or indirect_fanout:
+                            branch_leaves.append(new_branch)
+                        else:
+                            branch_active.append(new_branch)
+                    leaves.extend(branch_leaves)
+                    next_active.extend(branch_active)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"  [warn] descent failed at {lvl['name']} "
+                          f"for {branch['entity_id']}: {exc}")
                     if branch["leaf"] is not empty_leaf:
                         leaves.append(branch)
                     continue
-
-                for i, m in enumerate(matches):
-                    cand_row = candidates[candidates[key_col] == m["name"]].iloc[0]
-                    new_names = dict(branch["names"])
-                    new_names[out_col] = m["name"]
-                    new_parent_path = dict(branch["parent_path"])
-                    if not is_last_level:
-                        new_parent_path[child_filter_col] = cand_row[child_filter_value_col]
-                    new_leaf = {
-                        "deepest_match": lvl["name"],
-                        "leaf_definition": str(cand_row["Definition"]).strip(),
-                        "mode_of_operation": m["mode_of_operation"],
-                        "evidence": m["evidence"],
-                        "reason": m["reason"],
-                        "confidence": m.get("confidence"),
-                    }
-                    new_path_meta = dict(branch["path_meta"])
-                    new_path_meta[out_col] = {
-                        "evidence": m["evidence"],
-                        "reason": m["reason"],
-                        "confidence": m.get("confidence"),
-                        "mode_of_operation": m["mode_of_operation"],
-                    }
-                    new_branch = {
-                        "entity_id": branch["entity_id"],
-                        "entity_name": branch["entity_name"],
-                        "entity_description": branch["entity_description"],
-                        "names": new_names,
-                        "parent_path": new_parent_path,
-                        "leaf": new_leaf,
-                        "path_meta": new_path_meta,
-                        "start_idx": branch["start_idx"],
-                    }
-                    # Indirect-fanout stop: an `indirect` (advocacy /
-                    # policy / education) match descends only when it
-                    # is the SOLE match at this step. Multiple indirect
-                    # siblings = broad advocacy; naming any specific
-                    # child would be guesswork, so record at the
-                    # current level instead.
-                    indirect_fanout = (
-                        m["mode_of_operation"] == "indirect"
-                        and len(matches) > 1
-                    )
-                    if is_last_level or i >= descent_fanout_cap or indirect_fanout:
-                        leaves.append(new_branch)
-                    else:
-                        next_active.append(new_branch)
 
         active = next_active
         if not active:

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -643,7 +643,8 @@ def classify_entities(
     confidence_threshold: float | None = None,
     emit_per_level: bool = False,
     seed_col: str | None = None,
-    use_cached_result: bool = True,
+    read_from_cache: bool = True,
+    write_to_cache: bool = True,
 ) -> pd.DataFrame:
     """Classify many entities against the taxonomy via a SQL-cached walk.
 
@@ -708,9 +709,13 @@ def classify_entities(
         Optional input column whose value pre-seeds the walk at the
         top level (the walk descends that node's subtree). Used by the
         recovery flow to second-walk entities the first pass left empty.
-    use_cached_result
-        When False, bypass cached rows and re-issue the API call; the
-        new response overwrites the cache entry.
+    read_from_cache
+        When False, bypass cached rows and re-issue every API call
+        (force-refresh). Default True.
+    write_to_cache
+        When False, leave the cache untouched (read-only / passthrough).
+        Also gated by the cache's constructor-level ``store_results``.
+        Default True.
     """
     levels = normalize_levels(levels)
     last_idx = levels[-1]["idx"]
@@ -795,7 +800,8 @@ def classify_entities(
             print(f"  [{lvl['name']}] {len(requests)} request(s)")
             responses = cache.bulk_get_cache_or_run(
                 given_ids_texts=[(gid, txt) for gid, txt, _, _ in requests],
-                use_cached_result=use_cached_result,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
                 max_workers=max_workers,
             )
 
@@ -1073,7 +1079,8 @@ def recover_unmatched(
     category_choices: Iterable[str] | None = None,
     scope_prompt: str | None = None,
     max_workers: int = 8,
-    use_cached_result: bool = True,
+    read_from_cache: bool = True,
+    write_to_cache: bool = True,
 ) -> pd.DataFrame:
     """Second-stage scope check on entities the walk left unmatched.
 
@@ -1155,7 +1162,8 @@ def recover_unmatched(
 
         responses = cache.bulk_get_cache_or_run(
             given_ids_texts=requests,
-            use_cached_result=use_cached_result,
+            read_from_cache=read_from_cache,
+            write_to_cache=write_to_cache,
             max_workers=max_workers,
         )
 

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -620,6 +620,7 @@ def classify_entities(
     write_to_cache: bool = True,
     match_schema: type[BaseModel] | None = None,
     temperature: float | None = 0,
+    filter_by_model: bool = False,
 ) -> pd.DataFrame:
     """Classify many entities against the taxonomy via a SQL-cached walk.
 
@@ -712,6 +713,15 @@ def classify_entities(
         Automatically suppressed for reasoning models (``gpt-5*``),
         which reject the parameter — those models use their own
         sampling internally. Pass ``None`` to omit entirely.
+    filter_by_model
+        When True, cache rows are scoped by model name, so the same
+        prompt + text under different models (e.g. ``gpt-4.1`` vs
+        ``gpt-5.4-nano``) get separate cache entries. Default False
+        shares rows across models — which means a lookup can return
+        another model's answer for an identical prompt + text. **Set
+        this True whenever you run more than one model against the same
+        taxonomy**, otherwise a model switch silently reuses the prior
+        model's cached results.
     """
     levels = normalize_levels(levels)
     last_idx = levels[-1]["idx"]
@@ -735,6 +745,7 @@ def classify_entities(
         system_prompt=system_prompt,
         model=model,
         response_model=response_model,
+        filter_by_model=filter_by_model,
     )
 
     # Initialize one branch per entity. Carry each input row's columns

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -150,7 +150,6 @@ for still appear with all level columns null.
 
 from __future__ import annotations
 
-import json
 import time
 from pathlib import Path
 from typing import Any, Iterable
@@ -337,20 +336,14 @@ def _default_rule_bodies(levels: list[dict]) -> dict[str, str]:
     }
 
 
-_OUTPUT_CONSTRAINTS = (
-    "Output constraints:\n"
-    "- `index` must be the integer shown before a candidate in the "
-    "list. Indices are 1-based and must match a number actually shown "
-    "in the candidate list. Do not invent indices and do not return "
-    "names. To indicate no match, return `matches: []` — never return "
-    "index 0 or any index outside the listed range."
-)
-
 _TASK_FRAMING = (
     "You will be given an entity description and a numbered list of "
     "candidate nodes (name + definition) at a single level of the "
     "hierarchy. Identify which node(s) the description shows the "
-    "entity is actually working on."
+    "entity is actually working on. Output strict JSON matching the "
+    "response schema you are given — per-field guidance lives in the "
+    "schema's field descriptions and selection-level guidance lives "
+    "on the response class's docstring."
 )
 
 
@@ -358,21 +351,20 @@ def build_system_prompt(
     *,
     levels: list[dict],
     domain_intro: str,
-    modes: list[dict] | None = None,
     rules: dict[str, str] | None = None,
-    include_confidence: bool = False,
-    match_schema: type[BaseModel] | None = None,
 ) -> str:
     """Assemble a hierarchical-taxonomy classification system prompt.
 
-    Composes a generic skeleton — ``domain_intro``, task framing, JSON
-    output schema, an optional Mode-of-operation section, eight
-    matching-rule slots, and output constraints — with any caller-
-    supplied overrides. Each rule has a generic default that contains
-    no domain examples (except rules 2 and 5, whose examples transfer
-    to any taxonomy). Pass ``rules={"<key>": "<override text>"}`` to
-    replace any rule with domain-specific wording; missing keys keep
-    their generic default.
+    Composes a generic prose skeleton: ``domain_intro``, task framing,
+    eight matching-rule slots (with overrides). The JSON output shape,
+    per-field guidance (mode definitions, confidence semantics), and
+    selection-level guidance (when to surface weak candidates) ALL live
+    on the Pydantic response class the driver passes to
+    ``classify_entities(match_schema=...)``. ``InstructorPRC`` appends
+    that class's JSON schema to the prompt, so the model sees field
+    descriptions and the response class's docstring there. Keeping those
+    on the schema is what makes prompt and structural enforcement
+    impossible to drift apart.
 
     Parameters
     ----------
@@ -382,83 +374,15 @@ def build_system_prompt(
         at <top> and <mid> levels" wording.
     domain_intro
         Opening paragraph framing what the taxonomy classifies.
-    modes
-        Optional list of mode dicts, each with ``name`` and
-        ``definition``. When provided, ``mode_of_operation`` appears
-        in the JSON schema and a "Mode of operation" section follows
-        the schema. When ``None``, both are omitted entirely. The
-        default rule bodies do not reference modes; supply rule
-        overrides if mode-aware language belongs in your rules.
     rules
         Optional dict mapping any of the keys in ``PROMPT_RULE_KEYS``
         to a full override body (without leading number). Missing
-        keys fall back to ``_default_rule_bodies(levels)``.
-    match_schema
-        Optional Pydantic class describing the per-match shape. When
-        provided, its JSON schema is rendered into the prompt in place
-        of the hardcoded shape. **Pass the same class to
-        ``classify_entities(match_schema=...)``** so the prompt and the
-        structural enforcement at the API layer match — otherwise the
-        model is forced (under OpenAI strict mode) to emit fields the
-        prompt doesn't describe. The ``modes`` / ``include_confidence``
-        flags still control the prose explanatory sections; the caller
-        is responsible for keeping the schema's fields in sync with
-        those flags.
+        keys fall back to ``_default_rule_bodies(levels)``. Domain-
+        specific selection rules (e.g. cross-pillar routing for OE)
+        also go here, either as overrides of a default rule or
+        appended by the driver after ``build_system_prompt`` returns.
     """
     overrides = rules or {}
-
-    # Optional confidence field — when present, each match carries a
-    # 0-1 confidence and downstream code can threshold on it (see
-    # ``confidence_threshold``). Enabling it also changes the matching
-    # disposition: the model surfaces plausible-but-weak candidates with
-    # low confidence instead of self-filtering, so the threshold becomes a
-    # genuine bidirectional precision/recall knob.
-    conf_field = '"confidence": <number 0-1>, ' if include_confidence else ''
-
-    # JSON output schema.
-    # When ``match_schema`` is supplied, render its JSON schema literally
-    # so the prompt prose matches the strict-mode enforcement the API
-    # layer will apply. Otherwise fall back to the hardcoded shape
-    # (legacy callers that haven't moved to per-project schemas yet).
-    if match_schema is not None:
-        rendered = json.dumps(match_schema.model_json_schema(), indent=2)
-        schema = "  " + rendered.replace("\n", "\n  ")
-    elif modes:
-        mode_union = " | ".join(f'"{m["name"]}"' for m in modes)
-        schema = (
-            '  {"matches": [{"index": <int>, '
-            f'"mode_of_operation": {mode_union}, '
-            + conf_field +
-            '"evidence": "<phrase(s) from the description that '
-            'support the match>", '
-            '"reason": "<how the evidence maps to the candidate '
-            'definition>"}]}'
-        )
-    else:
-        schema = (
-            '  {"matches": [{"index": <int>, '
-            + conf_field +
-            '"evidence": "<phrase(s) from the description that '
-            'support the match>", '
-            '"reason": "<how the evidence maps to the candidate '
-            'definition>"}]}'
-        )
-
-    # Optional mode-of-operation section.
-    if modes:
-        mode_lines = [
-            "Mode of operation — for each selected candidate, classify "
-            "HOW the entity relates to the matched candidate:"
-        ]
-        for m in modes:
-            mode_lines.append(f"- '{m['name']}': {m['definition']}")
-        mode_lines.append(
-            "Pick the mode that best fits the entity's primary "
-            "relationship to the matched candidate."
-        )
-        modes_section: str | None = "\n".join(mode_lines)
-    else:
-        modes_section = None
 
     defaults = _default_rule_bodies(levels)
     numbered_rules: list[str] = []
@@ -469,22 +393,8 @@ def build_system_prompt(
     parts: list[str] = [
         domain_intro,
         _TASK_FRAMING,
-        f"Return JSON of the form:\n{schema}",
+        "Matching rules:\n" + "\n".join(numbered_rules),
     ]
-    if modes_section is not None:
-        parts.append(modes_section)
-    parts.append("Matching rules:\n" + "\n".join(numbered_rules))
-    if include_confidence:
-        parts.append(
-            "Confidence. For each match, include a `confidence` in [0,1] "
-            "reflecting how strongly the description supports it (1 = the "
-            "description names the activity explicitly; lower = weaker or "
-            "more inferential support). Surface every candidate that "
-            "plausibly fits, including weak or uncertain ones with low "
-            "confidence — do not omit a plausible candidate just because "
-            "it is uncertain. A downstream threshold decides which to keep."
-        )
-    parts.append(_OUTPUT_CONSTRAINTS)
 
     return "\n\n".join(parts)
 

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -20,14 +20,17 @@ for that level to the model and ask for the best match(es):
 
 The walk yields one record per leaf in the resulting match tree — a leaf
 is a match that was either at the deepest level, had no children matched,
-truncated by the descent fan-out cap, or (when the prompt produces a
+truncated by the descent fan-out cap, or (when the ``match_schema`` has a
 ``mode_of_operation`` field) tagged ``indirect`` alongside other siblings.
 
 This module is taxonomy-agnostic. Callers (driver scripts) supply:
 
     * a level spec (see below),
-    * a system prompt string describing the matching task — assemble one
-      with ``build_system_prompt`` (see "System prompt" below),
+    * a system prompt string describing the matching task — assemble the
+      prose with ``build_system_prompt`` (see "System prompt" below),
+    * a Pydantic ``match_schema`` describing the per-match response shape
+      and carrying the per-field / selection guidance (see "Response
+      schema" below),
     * a taxonomy xlsx whose sheet names align with the level spec,
     * an entities DataFrame with id / name / text columns,
     * a SQLAlchemy session for the prompt/response cache (see "Caching").
@@ -79,10 +82,13 @@ applied by ``normalize_levels``; most levels need not set them.
 System prompt
 -------------
 The ``system_prompt`` passed to ``classify_entities`` can be any string,
-but in practice you should build it with ``build_system_prompt``, which
-assembles a generic skeleton (task framing, JSON output schema, eight
-numbered matching-rule slots, output constraints) and lets you customize
-the parts that vary per taxonomy.
+but in practice you should build the prose with ``build_system_prompt``,
+which assembles a generic skeleton (``domain_intro``, task framing, and
+eight numbered matching-rule slots) and lets you customize the parts
+that vary per taxonomy. It deliberately does NOT describe the JSON
+output shape — that lives on the Pydantic ``match_schema`` (see
+"Response schema" below), which ``InstructorPRC`` appends to the prompt
+automatically.
 
 The skeleton was extracted from the Drawdown driver, so the rule set
 and structure reflect what worked there. The eight rule keys, in order,
@@ -102,27 +108,22 @@ Each rule has a generic default that contains no domain examples
 energy" ambiguity — transfer to any taxonomy). Override any subset by
 passing ``rules={"<key>": "<full body without leading number>"}``.
 
-Three layers of customization, from least to most invasive:
+Two layers of prose customization:
 
     1. ``domain_intro`` (required) — opening paragraph framing what the
-       taxonomy classifies. Replaces the climate-mitigation framing
-       used by Drawdown.
-    2. ``modes`` (optional) — list of ``{"name", "definition"}`` dicts.
-       When provided, ``mode_of_operation`` appears in the JSON schema
-       and a "Mode of operation" section follows the schema. When
-       ``None``, both are omitted entirely. The default rule bodies do
-       not reference modes; if your modes belong inside specific rules,
-       supply rule overrides for those rules (Drawdown does this for
-       ``prominence`` and ``advocacy_depth``).
-    3. ``rules`` (optional) — dict mapping any of the eight keys above
+       taxonomy classifies.
+    2. ``rules`` (optional) — dict mapping any of the eight keys above
        to a full override. Use this when a generic default's wording
        isn't tight enough for your domain — typically because it needs
        domain-specific examples or terminology that improves model
-       accuracy.
+       accuracy. Domain-specific selection rules (e.g. One Earth's
+       cross-pillar routing) also go here, or are appended by the driver
+       after ``build_system_prompt`` returns.
 
-The Drawdown driver demonstrates all three layers — see
-``DRAWDOWN_DOMAIN_INTRO``, ``DRAWDOWN_MODES``, and
-``DRAWDOWN_RULE_OVERRIDES`` in ``drawdown_hierarchical_taxonomy_mapping.py``.
+The Drawdown and One Earth drivers demonstrate both layers — see
+``DRAWDOWN_DOMAIN_INTRO`` / ``DRAWDOWN_RULE_OVERRIDES`` in
+``drawdown_hierarchical_taxonomy_mapping.py`` and ``ONEEARTH_DOMAIN_INTRO``
+/ ``ONEEARTH_RULE_OVERRIDES`` in ``oe_hierarchical_taxonomy_mapping.py``.
 
 For a brand-new taxonomy with no special rules, the minimum is::
 
@@ -130,6 +131,38 @@ For a brand-new taxonomy with no special rules, the minimum is::
         levels=my_levels,
         domain_intro="You are classifying X against a hierarchical taxonomy of Y...",
     )
+
+Response schema
+---------------
+``classify_entities`` takes a Pydantic ``match_schema`` (defaulting to
+``MatchesResponse`` from ``taxonomy_mapping_cache``) that defines the
+per-match response shape AND carries all schema-level instruction:
+
+    * **Per-field guidance** — ``Field(description=...)`` on each field:
+      a ``mode_of_operation`` field's allowed values and their
+      definitions, the "1-based index" note, evidence / reason guidance.
+    * **Selection-level guidance** — the response class's docstring
+      (e.g. "self-filter weak candidates" vs "surface every plausible
+      candidate with low confidence").
+
+``InstructorPRC`` appends ``match_schema.schema_json()`` to the system
+prompt, so the model sees the field descriptions and the response class
+docstring there. Because the structural constraint (the schema) and its
+human-readable guidance are the same object, the prompt and the API's
+strict-mode enforcement cannot drift apart. The driver is responsible
+for pairing the right ``match_schema`` with the prose it built — see
+``oneearth_match_schema()`` next to ``build_oneearth_system_prompt()``
+for the pattern.
+
+Two consequences worth knowing:
+
+    * A field present in the schema is REQUIRED under strict mode (only
+      ``null`` allowed if typed ``T | None``). Don't include
+      ``mode_of_operation`` / ``confidence`` in a schema for a taxonomy
+      that doesn't use them, or the model is forced to emit them anyway.
+    * ``mode_of_operation == "indirect"`` with multiple sibling matches
+      triggers the "indirect-fanout stop". A schema without that field
+      yields ``mode == ""`` in the engine, so the stop never fires.
 
 Output schema
 -------------
@@ -598,7 +631,7 @@ def classify_entities(
     workers do API I/O only.
 
     Cache keys:
-        prompt_id = hash(system_prompt + MatchesResponse schema)
+        prompt_id = hash(system_prompt + match_schema JSON schema)
         given_id  = "<entity_id>|<level_name>|<sorted parent_path>"
         text_id   = hash(entity_name + description + level_name + candidates)
 
@@ -642,8 +675,10 @@ def classify_entities(
         Concurrency cap for the cache's API worker pool, applied per
         level batch.
     confidence_threshold
-        Drop matches whose confidence is below this. Requires the
-        system_prompt to have been built with ``include_confidence=True``.
+        Drop matches whose confidence is below this. Requires
+        ``match_schema`` to include a ``confidence`` field (e.g. OE's
+        ``OneEarthMatchesWithConfidenceResponse``); matches with no
+        confidence value are never dropped.
     emit_per_level
         When True, output gains ``<level> evidence / reason / confidence``
         columns for every level matched along the path.
@@ -659,15 +694,18 @@ def classify_entities(
         Also gated by the cache's constructor-level ``store_results``.
         Default True.
     match_schema
-        Optional Pydantic class for the per-match response shape. When
-        provided, drives both the cache's structured-output constraint
-        (via ``TaxonomyMatchCache(response_model=...)``) AND the response
-        parsing here. **Pass the same class to ``build_system_prompt(
-        match_schema=...)``** so the prompt prose matches the strict-mode
-        enforcement; otherwise the model is forced to emit fields the
-        prompt didn't describe. When ``None``, the default
-        ``MatchesResponse`` is used — permissive (mode + confidence
-        nullable) for backward compatibility.
+        Optional Pydantic class for the per-match response shape. Drives
+        the cache's structured-output constraint (via
+        ``TaxonomyMatchCache(response_model=...)``), the response parsing
+        here, AND — because ``InstructorPRC`` appends its
+        ``schema_json()`` to the system prompt — the model-facing
+        per-field / selection guidance (carried on the class's
+        ``Field(description=...)`` and its docstring; see "Response
+        schema" in the module docstring). The driver is responsible for
+        pairing this with the prose it passed to ``build_system_prompt``;
+        the two are not auto-validated against each other. When ``None``,
+        the default ``MatchesResponse`` is used — permissive (mode +
+        confidence nullable).
     temperature
         Sampling temperature for the model. Defaults to ``0`` to match
         the legacy ``call_openai_match`` path (deterministic outputs).

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -1118,6 +1118,7 @@ def recover_unmatched(
     read_from_cache: bool = True,
     write_to_cache: bool = True,
     temperature: float | None = 0,
+    filter_by_model: bool = False,
 ) -> pd.DataFrame:
     """Second-stage scope check on entities the walk left unmatched.
 
@@ -1149,6 +1150,12 @@ def recover_unmatched(
     prompt must instruct the model to populate the ``category`` field of
     the structured-output schema with the exact name of an in-scope
     top-level node (or null); ``ScopeDecision`` is the source of truth.
+
+    ``filter_by_model`` (default False, matching the engine default)
+    scopes the ``ScopeRecoveryCache`` rows by model name. Pass True when
+    A/B-comparing recovery models against the same scope prompt so the
+    second model does not silently reuse the first's cached decisions;
+    ``map_to_oneearth`` forwards its own ``filter_by_model`` here.
     """
     if top_level_col is None or category_choices is None or scope_prompt is None:
         if levels is None or tables is None:
@@ -1186,6 +1193,7 @@ def recover_unmatched(
             session=session,
             scope_prompt=scope_prompt,
             model=model,
+            filter_by_model=filter_by_model,
         )
 
         requests: list[tuple[str, str]] = []

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -363,10 +363,11 @@ ONEEARTH_LEVELS = [
 # ---------------------------------------------------------------------------
 # One Earth system prompt — assembled from generic skeleton + OE overrides
 # ---------------------------------------------------------------------------
-# Same three-layer customization the Drawdown driver uses: domain intro,
-# modes-of-operation (copied verbatim — definitions are domain-agnostic),
-# and rule overrides. ``evidence_only`` and ``multiple_matches`` use the
-# engine's defaults.
+# The prose prompt has two customization layers: a domain intro and rule
+# overrides (``evidence_only`` and ``multiple_matches`` use the engine's
+# defaults). The mode-of-operation definitions and the per-match response
+# shape live on the Pydantic ``OneEarthMatch`` classes above, NOT in this
+# prose — see ``oneearth_match_schema``.
 
 ONEEARTH_DOMAIN_INTRO = (
     "You are classifying an organization against the One Earth Climate "
@@ -497,16 +498,21 @@ ONEEARTH_CROSS_PILLAR_ROUTING = (
 
 
 def build_oneearth_system_prompt(include_confidence: bool = False) -> str:
-    """Assemble the canonical One Earth organization system prompt.
+    """Assemble the canonical One Earth organization system prompt (prose only).
 
     Generic prose skeleton + OE rule overrides + the standalone
     cross-pillar routing section. The mode definitions, the confidence
-    semantics, and the selection-vs-self-filter behavior all live on
-    the Pydantic response class (selected by
+    semantics, and the selection-vs-self-filter behavior all live on the
+    Pydantic response class (selected by
     ``oneearth_match_schema(include_confidence=...)``) — pass that same
     class to ``classify_entities(match_schema=...)`` so the model sees
     the schema's Field descriptions + response-class docstring via
     InstructorPRC's schema append.
+
+    ``include_confidence`` no longer affects the prose (confidence is a
+    schema-only concern now); the org prompt is identical either way. The
+    parameter is retained so existing call sites don't break — pick the
+    confidence-enabled SCHEMA via ``oneearth_match_schema`` instead.
     """
     prompt = build_system_prompt(
         levels=ONEEARTH_LEVELS,
@@ -523,21 +529,22 @@ ONEEARTH_SYSTEM_PROMPT = build_oneearth_system_prompt()
 # Research-project prompt variant
 # ---------------------------------------------------------------------------
 # The default prompt above is calibrated for organizations (companies,
-# NGOs, land trusts) — its modes describe what an "entity" does and its
-# rule overrides are full of organization-shaped examples ("land trust",
-# "Audubon-style organization", "regenerative-farming co-op"). Research-
-# grant abstracts (NSF, NIH, USAspending) describe investigations rather
-# than operations, and the org-tuned framing causes the LLM to miss
-# applied / mechanism research that legitimately maps to deployment-
-# shaped taxonomy nodes.
+# NGOs, land trusts) — its mode definitions describe what an "entity"
+# does and its rule overrides are full of organization-shaped examples
+# ("land trust", "Audubon-style organization", "regenerative-farming
+# co-op"). Research-grant abstracts (NSF, NIH, USAspending) describe
+# investigations rather than operations, and the org-tuned framing
+# causes the LLM to miss applied / mechanism research that legitimately
+# maps to deployment-shaped taxonomy nodes.
 #
-# The constants below provide a coordinated alternative — domain intro
-# framed for research projects, modes-of-operation reworded around
-# research roles (while keeping the engine's canonical mode names), and
-# rule overrides with research-shaped examples and exclusions. Callers
-# select the variant via ``map_to_oneearth(prompt_mode="research")``.
-# All three pieces move as a triple; mixing the org domain_intro with
-# research modes (or vice versa) produces incoherent prompts.
+# The research variant moves as a coordinated triple: the domain intro
+# and rule overrides below (prose) plus the ``OneEarthResearchMatch``
+# schema above (whose ``mode_of_operation`` Field reworded the mode
+# definitions around research roles, keeping the canonical mode names).
+# Callers select the variant via ``map_to_oneearth(prompt_mode=
+# "research")``, which pairs ``ONEEARTH_RESEARCH_SYSTEM_PROMPT`` with
+# ``oneearth_match_schema(research=True)``. Mixing the org prose with the
+# research schema (or vice versa) produces incoherent prompts.
 
 ONEEARTH_RESEARCH_DOMAIN_INTRO = (
     "You are classifying a description of a scientific research project "
@@ -997,24 +1004,26 @@ def map_to_oneearth(
     prompt_mode
         ``"organization"`` (default): the standard OE system prompt,
         calibrated for organizations (companies, NGOs, land trusts).
-        ``"research"``: a research-project variant that swaps domain
-        intro, modes-of-operation, and rule overrides as a coordinated
-        triple — framed for grant abstracts (NSF, NIH, USAspending).
-        Same taxonomy and walk, different framing. The three pieces
-        move together; mixing org and research framing produces
-        incoherent prompts. Ignored when ``system_prompt`` is set.
+        ``"research"``: a research-project variant — framed for grant
+        abstracts (NSF, NIH, USAspending). Selecting a mode pairs the
+        matching prose prompt with the matching ``match_schema`` (org vs
+        ``OneEarthResearchMatch``); both move together. Same taxonomy and
+        walk, different framing. Ignored when ``system_prompt`` is set
+        (in which case the org schema is used).
     system_prompt
         Escape hatch for callers that want to assemble a fully custom
         system prompt via ``build_system_prompt``. When provided, it
-        overrides ``prompt_mode`` entirely.
+        overrides ``prompt_mode`` entirely (and the organization match
+        schema is used).
     confidence_threshold
-        Precision/recall knob in [0, 1]. When set, the ``system_prompt``
-        must be confidence-enabled (``build_system_prompt(
-        include_confidence=True)``); the model emits a per-match
-        confidence and matches below the threshold are dropped. LOWER
-        keeps more (weaker) matches — fewer no-mappings, more false
-        positives; HIGHER keeps only strong matches. ``None`` (default)
-        applies no confidence scoring or filtering.
+        Precision/recall knob in [0, 1]. When set (organization mode
+        only), the confidence-enabled schema
+        (``OneEarthMatchesWithConfidenceResponse``) is selected so the
+        model emits a per-match confidence, and matches below the
+        threshold are dropped. LOWER keeps more (weaker) matches — fewer
+        no-mappings, more false positives; HIGHER keeps only strong
+        matches. ``None`` (default) applies no confidence scoring or
+        filtering.
     emit_per_level
         When True, the per-row frame gains ``<level> evidence`` /
         ``<level> reason`` / ``<level> confidence`` columns for every

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -50,7 +50,7 @@ from pathlib import Path
 from typing import Literal
 
 import pandas as pd
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping as _htm
 from vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping import (
@@ -63,53 +63,206 @@ from vdl_tools.shared_tools.database_cache.database_utils import get_session
 # ---------------------------------------------------------------------------
 # Per-project match schema
 # ---------------------------------------------------------------------------
-# OE uses three modes (direct / enabling tech / indirect) — same set for
-# the organization and research prompt variants. The schema is
-# constrained to those three literals so the model can't emit anything
-# else under strict-mode structured output. The "with confidence"
-# variant adds a required ``confidence: float`` for the
-# ``confidence_threshold`` knob.
+# OE uses three modes (direct / enabling tech / indirect) for both the
+# organization and research prompt variants. The Literal constrains the
+# model to those three values under strict-mode structured output; the
+# Field descriptions on the per-variant Match subclasses carry the
+# domain-specific definitions, and the response-class docstrings carry
+# the selection behavior. ``InstructorPRC`` appends the schema JSON to
+# the prompt so the model sees all three layers (Literal constraint,
+# Field descriptions, response-class docstring) without any prose
+# scaffolding in ``build_system_prompt``.
 #
-# Hand the same class to ``build_system_prompt(match_schema=...)`` and
-# ``classify_entities(match_schema=...)`` so prompt prose matches the
-# strict-mode enforcement at the API layer.
+# Pass the right response class to ``classify_entities(match_schema=...)``
+# via ``oneearth_match_schema(...)``.
 
-_OE_MODE = Literal["direct", "enabling tech", "indirect"]
+# Mode definitions — kept as plain dicts so the Literal and the
+# Field descriptions derive from one source. Org and research share mode
+# NAMES but have different definitions.
+
+_OE_MODE_DEFINITIONS: dict[str, str] = {
+    "direct": (
+        "the entity itself deploys, operates, produces, implements, "
+        "or performs the solution activity (e.g. builds solar farms, "
+        "runs regenerative agriculture, manufactures low-carbon "
+        "cement, restores wetlands)."
+    ),
+    "enabling tech": (
+        "the entity develops or supplies technology, hardware, "
+        "software, tools, materials, financing, or services that "
+        "make the solution possible for others to deploy, but does "
+        "not deploy it itself at scale (e.g. sells sensors to wind "
+        "farms, builds software for grid operators, provides capital "
+        "to project developers)."
+    ),
+    "indirect": (
+        "the entity works on public policy, advocacy, awareness, "
+        "education, standards, research without deployment, "
+        "convening, or other non-deployment levers of change that "
+        "shape whether or how the solution is adopted."
+    ),
+}
+
+_OE_RESEARCH_MODE_DEFINITIONS: dict[str, str] = {
+    "direct": (
+        "the project itself implements, deploys, restores, "
+        "sequesters, manufactures, or runs a field demonstration "
+        "of the named solution at real-world scale — e.g. installs "
+        "a microgrid, restores wetlands at a specific site, runs a "
+        "methane-leak monitoring deployment, plants cover crops on "
+        "working farms, field-trials a geoengineering intervention. "
+        "This is the rarest mode in research-grant data; most "
+        "research is upstream of deployment."
+    ),
+    "enabling tech": (
+        "the project develops, validates, characterizes, "
+        "prototypes, or investigates the mechanism behind a "
+        "specific named technology, material, process, or practice "
+        "that maps to a taxonomy node. This covers BOTH applied "
+        "R&D (synthesizing battery electrolytes, designing a "
+        "perovskite PV cell, building a methane-detection sensor) "
+        "AND mechanism / foundational research where the abstract "
+        "names both the mechanism AND a specific solution domain "
+        "it informs (e.g. plant nutrient-sensing for low-fertilizer "
+        "crops, soil-microbe interactions for carbon stabilization, "
+        "computational methods explicitly for clean-energy materials). "
+        "Most research-grant abstracts that match the taxonomy "
+        "fall in this mode."
+    ),
+    "indirect": (
+        "the project produces field-building infrastructure or "
+        "soft levers for the climate field — climate-science "
+        "instrumentation that supports many solutions, satellite "
+        "monitoring, lifecycle assessments, multi-pillar policy / "
+        "regulatory analysis, capacity-building research, "
+        "education / outreach research. Typically Cross-Cutting; "
+        "use this mode when the research output is a tool or "
+        "framework rather than the development of a specific "
+        "named solution."
+    ),
+}
+
+# Both variants share the same Literal — keys must agree across the
+# two definition dicts. (3.11+: Literal[*dict.keys()] unpacking.)
+assert tuple(_OE_MODE_DEFINITIONS) == tuple(_OE_RESEARCH_MODE_DEFINITIONS), (
+    "OE org and research mode dicts must share key order"
+)
+_OE_MODE = Literal[*_OE_MODE_DEFINITIONS]
+
+
+def _mode_field(definitions: dict[str, str]):
+    """Build the Field for ``mode_of_operation`` with definitions inline."""
+    return Field(
+        description=(
+            "How the entity relates to the matched candidate. Pick the "
+            "mode that best fits the entity's primary relationship.\n"
+            + "\n".join(f"- {k}: {v}" for k, v in definitions.items())
+        ),
+    )
+
+
+_INDEX_FIELD = Field(
+    description=(
+        "The 1-based position of the matched candidate in the numbered "
+        "candidate list shown in the user prompt. Never return 0 or an "
+        "out-of-range index — to indicate no match, return `matches: []`."
+    ),
+)
+_EVIDENCE_FIELD = Field(
+    default="",
+    description=(
+        "Phrase(s) from the entity description that support the match. "
+        "Quote or closely paraphrase the supporting language. If no "
+        "language in the description supports the candidate, omit the "
+        "match — do not invent evidence."
+    ),
+)
+_REASON_FIELD = Field(
+    default="",
+    description=(
+        "One sentence explaining how the evidence maps to the candidate's "
+        "definition."
+    ),
+)
 
 
 class OneEarthMatch(BaseModel):
-    """Per-match shape for organization / research OE prompts (no confidence)."""
+    """Per-match shape for the organization OE prompt (no confidence)."""
 
-    index: int
-    mode_of_operation: _OE_MODE
-    evidence: str = ""
-    reason: str = ""
+    index: int = _INDEX_FIELD
+    mode_of_operation: _OE_MODE = _mode_field(_OE_MODE_DEFINITIONS)
+    evidence: str = _EVIDENCE_FIELD
+    reason: str = _REASON_FIELD
 
 
 class OneEarthMatchesResponse(BaseModel):
+    """Default OE selection behavior: emit only the matches the
+    description clearly supports — self-filter weak candidates. A match
+    requires a specific phrase from the description that names the
+    candidate's activity."""
+
     matches: list[OneEarthMatch] = []
 
 
-class OneEarthMatchWithConfidence(BaseModel):
-    """Per-match shape with confidence enabled (used with confidence_threshold)."""
+class OneEarthMatchWithConfidence(OneEarthMatch):
+    """Per-match shape with confidence enabled (used with
+    ``confidence_threshold``)."""
 
-    index: int
-    mode_of_operation: _OE_MODE
-    evidence: str = ""
-    reason: str = ""
-    confidence: float
+    confidence: float = Field(
+        description=(
+            "Confidence in [0, 1] that the description supports this "
+            "match. 1 = the description names the activity explicitly; "
+            "lower values reflect weaker or more inferential support."
+        ),
+    )
 
 
 class OneEarthMatchesWithConfidenceResponse(BaseModel):
+    """Confidence-enabled OE selection behavior: surface every candidate
+    the description could plausibly support — including weak ones, with
+    low confidence — rather than self-filtering. A downstream threshold
+    decides which to keep. Do not omit a plausible candidate just because
+    it is uncertain; emit it with a low confidence value instead."""
+
     matches: list[OneEarthMatchWithConfidence] = []
 
 
-def oneearth_match_schema(include_confidence: bool = False) -> type[BaseModel]:
-    """Return the OE match-response Pydantic class for a given confidence flag.
+class OneEarthResearchMatch(BaseModel):
+    """Per-match shape for the research-project OE prompt."""
 
-    Mirrors the ``include_confidence`` flag passed to
-    ``build_oneearth_system_prompt`` / ``build_system_prompt``.
+    index: int = _INDEX_FIELD
+    mode_of_operation: _OE_MODE = _mode_field(_OE_RESEARCH_MODE_DEFINITIONS)
+    evidence: str = _EVIDENCE_FIELD
+    reason: str = _REASON_FIELD
+
+
+class OneEarthResearchMatchesResponse(BaseModel):
+    """Research-prompt selection behavior: a match requires the abstract
+    to name a research activity (development, validation, mechanism
+    investigation, etc.) targeting the candidate's domain — not just
+    passing climate vocabulary in a broader-impacts statement."""
+
+    matches: list[OneEarthResearchMatch] = []
+
+
+def oneearth_match_schema(
+    *,
+    include_confidence: bool = False,
+    research: bool = False,
+) -> type[BaseModel]:
+    """Return the OE match-response Pydantic class for a given variant.
+
+    ``include_confidence`` enables the confidence field (only meaningful
+    for the organization prompt). ``research=True`` returns the
+    research-project variant, which uses different mode definitions and
+    does not support confidence.
     """
+    if research:
+        if include_confidence:
+            raise ValueError(
+                "research variant does not support include_confidence yet"
+            )
+        return OneEarthResearchMatchesResponse
     return (
         OneEarthMatchesWithConfidenceResponse if include_confidence
         else OneEarthMatchesResponse
@@ -242,39 +395,9 @@ ONEEARTH_DOMAIN_INTRO = (
     "angle, or generic economic development."
 )
 
-# Copied verbatim from the Drawdown driver — the definitions are
-# domain-agnostic and transfer cleanly.
-ONEEARTH_MODES = [
-    {
-        "name": "direct",
-        "definition": (
-            "the entity itself deploys, operates, produces, implements, "
-            "or performs the solution activity (e.g. builds solar farms, "
-            "runs regenerative agriculture, manufactures low-carbon "
-            "cement, restores wetlands)."
-        ),
-    },
-    {
-        "name": "enabling tech",
-        "definition": (
-            "the entity develops or supplies technology, hardware, "
-            "software, tools, materials, financing, or services that "
-            "make the solution possible for others to deploy, but does "
-            "not deploy it itself at scale (e.g. sells sensors to wind "
-            "farms, builds software for grid operators, provides capital "
-            "to project developers)."
-        ),
-    },
-    {
-        "name": "indirect",
-        "definition": (
-            "the entity works on public policy, advocacy, awareness, "
-            "education, standards, research without deployment, "
-            "convening, or other non-deployment levers of change that "
-            "shape whether or how the solution is adopted."
-        ),
-    },
-]
+# NOTE: mode-of-operation definitions live in ``_OE_MODE_DEFINITIONS`` at
+# the top of this file (consumed by the ``OneEarthMatch.mode_of_operation``
+# Field description). No standalone ``ONEEARTH_MODES`` constant.
 
 ONEEARTH_RULE_OVERRIDES = {
     "domain_relevance": (
@@ -376,19 +499,19 @@ ONEEARTH_CROSS_PILLAR_ROUTING = (
 def build_oneearth_system_prompt(include_confidence: bool = False) -> str:
     """Assemble the canonical One Earth organization system prompt.
 
-    Generic skeleton + OE rule overrides (domain_relevance with a
-    Pillar-level inclusion bias, generic cross_sector, prominence) + the
-    standalone cross-pillar routing section. ``include_confidence=True``
-    adds the per-match confidence schema/instruction for the
-    confidence-threshold knob.
+    Generic prose skeleton + OE rule overrides + the standalone
+    cross-pillar routing section. The mode definitions, the confidence
+    semantics, and the selection-vs-self-filter behavior all live on
+    the Pydantic response class (selected by
+    ``oneearth_match_schema(include_confidence=...)``) — pass that same
+    class to ``classify_entities(match_schema=...)`` so the model sees
+    the schema's Field descriptions + response-class docstring via
+    InstructorPRC's schema append.
     """
     prompt = build_system_prompt(
         levels=ONEEARTH_LEVELS,
         domain_intro=ONEEARTH_DOMAIN_INTRO,
-        modes=ONEEARTH_MODES,
         rules=ONEEARTH_RULE_OVERRIDES,
-        include_confidence=include_confidence,
-        match_schema=oneearth_match_schema(include_confidence),
     )
     return prompt + "\n\n" + ONEEARTH_CROSS_PILLAR_ROUTING
 
@@ -452,53 +575,9 @@ ONEEARTH_RESEARCH_DOMAIN_INTRO = (
 # canonical mode names (direct / enabling tech / indirect) so the
 # engine's hardcoded validation accepts the values without warning and
 # downstream mode-aware logic (e.g. indirect-fanout stop) keeps working.
-ONEEARTH_RESEARCH_MODES = [
-    {
-        "name": "direct",
-        "definition": (
-            "the project itself implements, deploys, restores, "
-            "sequesters, manufactures, or runs a field demonstration "
-            "of the named solution at real-world scale — e.g. installs "
-            "a microgrid, restores wetlands at a specific site, runs a "
-            "methane-leak monitoring deployment, plants cover crops on "
-            "working farms, field-trials a geoengineering intervention. "
-            "This is the rarest mode in research-grant data; most "
-            "research is upstream of deployment."
-        ),
-    },
-    {
-        "name": "enabling tech",
-        "definition": (
-            "the project develops, validates, characterizes, "
-            "prototypes, or investigates the mechanism behind a "
-            "specific named technology, material, process, or practice "
-            "that maps to a taxonomy node. This covers BOTH applied "
-            "R&D (synthesizing battery electrolytes, designing a "
-            "perovskite PV cell, building a methane-detection sensor) "
-            "AND mechanism / foundational research where the abstract "
-            "names both the mechanism AND a specific solution domain "
-            "it informs (e.g. plant nutrient-sensing for low-fertilizer "
-            "crops, soil-microbe interactions for carbon stabilization, "
-            "computational methods explicitly for clean-energy materials). "
-            "Most research-grant abstracts that match the taxonomy "
-            "fall in this mode."
-        ),
-    },
-    {
-        "name": "indirect",
-        "definition": (
-            "the project produces field-building infrastructure or "
-            "soft levers for the climate field — climate-science "
-            "instrumentation that supports many solutions, satellite "
-            "monitoring, lifecycle assessments, multi-pillar policy / "
-            "regulatory analysis, capacity-building research, "
-            "education / outreach research. Typically Cross-Cutting; "
-            "use this mode when the research output is a tool or "
-            "framework rather than the development of a specific "
-            "named solution."
-        ),
-    },
-]
+# Research-flavored mode definitions live in
+# ``_OE_RESEARCH_MODE_DEFINITIONS`` at the top of this file (consumed by
+# the ``OneEarthResearchMatch.mode_of_operation`` Field description).
 
 ONEEARTH_RESEARCH_RULE_OVERRIDES = {
     "domain_relevance": (
@@ -736,9 +815,7 @@ ONEEARTH_RESEARCH_RULE_OVERRIDES = {
 ONEEARTH_RESEARCH_SYSTEM_PROMPT = build_system_prompt(
     levels=ONEEARTH_LEVELS,
     domain_intro=ONEEARTH_RESEARCH_DOMAIN_INTRO,
-    modes=ONEEARTH_RESEARCH_MODES,
     rules=ONEEARTH_RESEARCH_RULE_OVERRIDES,
-    match_schema=oneearth_match_schema(include_confidence=False),
 )
 
 
@@ -979,15 +1056,17 @@ def map_to_oneearth(
         taxonomy_path = find_latest_taxonomy(taxonomy_dir)
     tables = load_taxonomy(taxonomy_path)
 
-    # Derive the per-match Pydantic schema alongside the system_prompt so
-    # the prompt prose and the strict-mode structured-output constraint
-    # at the API layer match. The schema's mode_of_operation is a
-    # Literal over the three OE modes; confidence is only required when
-    # the confidence-threshold knob is in use.
+    # Pick the per-match Pydantic class to match the system_prompt
+    # variant. Confidence is only meaningful under the organization
+    # prompt; research uses its own Match class with research-flavored
+    # mode definitions.
     confidence_on = (
         confidence_threshold is not None and prompt_mode == "organization"
     )
-    match_schema = oneearth_match_schema(include_confidence=confidence_on)
+    match_schema = oneearth_match_schema(
+        include_confidence=confidence_on,
+        research=(prompt_mode == "research"),
+    )
 
     if system_prompt is None:
         if confidence_on:
@@ -1122,14 +1201,20 @@ __all__ = [
     "ONEEARTH_LEVELS",
     # Organization-tuned prompt (default).
     "ONEEARTH_DOMAIN_INTRO",
-    "ONEEARTH_MODES",
     "ONEEARTH_RULE_OVERRIDES",
     "ONEEARTH_SYSTEM_PROMPT",
     # Research-project-tuned prompt (prompt_mode="research").
     "ONEEARTH_RESEARCH_DOMAIN_INTRO",
-    "ONEEARTH_RESEARCH_MODES",
     "ONEEARTH_RESEARCH_RULE_OVERRIDES",
     "ONEEARTH_RESEARCH_SYSTEM_PROMPT",
+    # Per-project Pydantic match schemas (pass to classify_entities).
+    "OneEarthMatch",
+    "OneEarthMatchesResponse",
+    "OneEarthMatchWithConfidence",
+    "OneEarthMatchesWithConfidenceResponse",
+    "OneEarthResearchMatch",
+    "OneEarthResearchMatchesResponse",
+    "oneearth_match_schema",
     "find_latest_taxonomy",
     "load_taxonomy",
     "collapse_to_one_row_per_uid",

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -1059,7 +1059,7 @@ __all__ = [
 if __name__ == "__main__":
     taxonomy_dir = find_latest_taxonomy(Path("../shared-data-clean/data/taxonomies/oneearth"))
     entities = pd.DataFrame([
-        {"id": 1, "name": "CCS", "description": "CCS is a project developer focusing on building carbon capture and storage facilities."},
+        {"id": 1, "name": "CCS", "description": "CCS is a project developer focusing on building carbon capture and storage facilities. They also make fertilizer from captured carbon dioxide."},
         {"id": 2, "name": "Electric Semis", "description": "Electric Semis is an auto manufacturer focusing on building electric semi-trucks. They also build battery storage systems."},
         {"id": 3, "name": "Forest Defense Fund", "description": "Forest Defense Fund is a non-profit organization focusing on protecting forests and wildlife."},
     ])
@@ -1069,5 +1069,7 @@ if __name__ == "__main__":
         id_col="id",
         name_col="name",
         text_col="description",
+        read_from_cache=True,
+        write_to_cache=True,
     )
     print(results)

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -17,10 +17,10 @@ This is the data + prompt half. The CFT-specific driver (loading the
 CFT JSON, sampling, writing the xlsx triplet, comparing to the prior
 ``One Earth *`` columns) lives in ``run_oe_hierarchical_mapping.py``.
 
-Eventual home: ``vdl_tools/shared_tools/taxonomy_mapping/``. Once moved
-there, ``SHARED_TAXONOMY_DIR`` should be relativized via
-``vdl_tools.shared_tools.project_config`` rather than the absolute path
-used here for now.
+The taxonomy xlsx location is caller-supplied: pass ``taxonomy_path``
+(an xlsx) or ``taxonomy_dir`` (searched for the latest
+``OE Solutions Terms *VDL.xlsx``) to ``map_to_oneearth``. There is no
+built-in default path.
 
 High-level usage
 ----------------
@@ -855,6 +855,7 @@ def map_to_oneearth(
     model: str = MODEL,
     max_workers: int = DEFAULT_WORKERS,
     taxonomy_path: Path | None = None,
+    taxonomy_dir: Path | None = None,
     descent_fanout_cap: int = DESCENT_FANOUT_CAP,
     prompt_mode: str = "organization",
     system_prompt: str | None = None,
@@ -906,9 +907,13 @@ def map_to_oneearth(
         When False, leave the cache untouched (read-only / passthrough).
         Default True.
     taxonomy_path
-        Optional override for the taxonomy xlsx. Defaults to
-        ``find_latest_taxonomy()`` which picks the latest VDL-edited
-        ``OE Solutions Terms *VDL.xlsx`` from ``SHARED_TAXONOMY_DIR``.
+        Path to the taxonomy xlsx. If omitted, ``taxonomy_dir`` must be
+        provided and the latest ``OE Solutions Terms *VDL.xlsx`` found in
+        it (via ``find_latest_taxonomy``) is used.
+    taxonomy_dir
+        Directory searched for the latest ``OE Solutions Terms *VDL.xlsx``
+        when ``taxonomy_path`` is not given. One of ``taxonomy_path`` /
+        ``taxonomy_dir`` is required — there is no built-in default path.
     descent_fanout_cap
         Maximum number of children to descend into when a level returns
         multiple matches. Default 3.
@@ -965,7 +970,13 @@ def map_to_oneearth(
         raise ValueError("walk_recovered=True requires recover_unmatched=True")
 
     if taxonomy_path is None:
-        taxonomy_path = find_latest_taxonomy()
+        if taxonomy_dir is None:
+            raise ValueError(
+                "map_to_oneearth: pass taxonomy_path=<xlsx> or taxonomy_dir="
+                "<dir searched via find_latest_taxonomy>. There is no "
+                "built-in default taxonomy location."
+            )
+        taxonomy_path = find_latest_taxonomy(taxonomy_dir)
     tables = load_taxonomy(taxonomy_path)
 
     # Derive the per-match Pydantic schema alongside the system_prompt so
@@ -1107,7 +1118,6 @@ __all__ = [
     "MODEL",
     "DESCENT_FANOUT_CAP",
     "DEFAULT_WORKERS",
-    "SHARED_TAXONOMY_DIR",
     "PILLAR_DETAIL_SHEETS",
     "ONEEARTH_LEVELS",
     # Organization-tuned prompt (default).
@@ -1131,7 +1141,6 @@ __all__ = [
 
 
 if __name__ == "__main__":
-    taxonomy_dir = find_latest_taxonomy(Path("../shared-data-clean/data/taxonomies/oneearth"))
     entities = pd.DataFrame([
         {"id": 1, "name": "CCS", "description": "CCS is a project developer focusing on building carbon capture and storage facilities. They also make fertilizer from captured carbon dioxide."},
         {"id": 2, "name": "Electric Semis", "description": "Electric Semis is an auto manufacturer focusing on building electric semi-trucks. They also build battery storage systems."},
@@ -1139,7 +1148,7 @@ if __name__ == "__main__":
     ])
     results = map_to_oneearth(
         entities=entities,
-        taxonomy_path=taxonomy_dir,
+        taxonomy_dir=Path("../shared-data-clean/data/taxonomies/oneearth"),
         id_col="id",
         name_col="name",
         text_col="description",

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -47,8 +47,10 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Literal
 
 import pandas as pd
+from pydantic import BaseModel
 
 import vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping as _htm
 from vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping import (
@@ -56,6 +58,62 @@ from vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping impor
     classify_entities,
 )
 from vdl_tools.shared_tools.database_cache.database_utils import get_session
+
+
+# ---------------------------------------------------------------------------
+# Per-project match schema
+# ---------------------------------------------------------------------------
+# OE uses three modes (direct / enabling tech / indirect) — same set for
+# the organization and research prompt variants. The schema is
+# constrained to those three literals so the model can't emit anything
+# else under strict-mode structured output. The "with confidence"
+# variant adds a required ``confidence: float`` for the
+# ``confidence_threshold`` knob.
+#
+# Hand the same class to ``build_system_prompt(match_schema=...)`` and
+# ``classify_entities(match_schema=...)`` so prompt prose matches the
+# strict-mode enforcement at the API layer.
+
+_OE_MODE = Literal["direct", "enabling tech", "indirect"]
+
+
+class OneEarthMatch(BaseModel):
+    """Per-match shape for organization / research OE prompts (no confidence)."""
+
+    index: int
+    mode_of_operation: _OE_MODE
+    evidence: str = ""
+    reason: str = ""
+
+
+class OneEarthMatchesResponse(BaseModel):
+    matches: list[OneEarthMatch] = []
+
+
+class OneEarthMatchWithConfidence(BaseModel):
+    """Per-match shape with confidence enabled (used with confidence_threshold)."""
+
+    index: int
+    mode_of_operation: _OE_MODE
+    evidence: str = ""
+    reason: str = ""
+    confidence: float
+
+
+class OneEarthMatchesWithConfidenceResponse(BaseModel):
+    matches: list[OneEarthMatchWithConfidence] = []
+
+
+def oneearth_match_schema(include_confidence: bool = False) -> type[BaseModel]:
+    """Return the OE match-response Pydantic class for a given confidence flag.
+
+    Mirrors the ``include_confidence`` flag passed to
+    ``build_oneearth_system_prompt`` / ``build_system_prompt``.
+    """
+    return (
+        OneEarthMatchesWithConfidenceResponse if include_confidence
+        else OneEarthMatchesResponse
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +388,7 @@ def build_oneearth_system_prompt(include_confidence: bool = False) -> str:
         modes=ONEEARTH_MODES,
         rules=ONEEARTH_RULE_OVERRIDES,
         include_confidence=include_confidence,
+        match_schema=oneearth_match_schema(include_confidence),
     )
     return prompt + "\n\n" + ONEEARTH_CROSS_PILLAR_ROUTING
 
@@ -679,6 +738,7 @@ ONEEARTH_RESEARCH_SYSTEM_PROMPT = build_system_prompt(
     domain_intro=ONEEARTH_RESEARCH_DOMAIN_INTRO,
     modes=ONEEARTH_RESEARCH_MODES,
     rules=ONEEARTH_RESEARCH_RULE_OVERRIDES,
+    match_schema=oneearth_match_schema(include_confidence=False),
 )
 
 
@@ -908,8 +968,18 @@ def map_to_oneearth(
         taxonomy_path = find_latest_taxonomy()
     tables = load_taxonomy(taxonomy_path)
 
+    # Derive the per-match Pydantic schema alongside the system_prompt so
+    # the prompt prose and the strict-mode structured-output constraint
+    # at the API layer match. The schema's mode_of_operation is a
+    # Literal over the three OE modes; confidence is only required when
+    # the confidence-threshold knob is in use.
+    confidence_on = (
+        confidence_threshold is not None and prompt_mode == "organization"
+    )
+    match_schema = oneearth_match_schema(include_confidence=confidence_on)
+
     if system_prompt is None:
-        if confidence_threshold is not None and prompt_mode == "organization":
+        if confidence_on:
             # The confidence knob needs the confidence-enabled schema.
             system_prompt = build_oneearth_system_prompt(include_confidence=True)
         elif prompt_mode not in _PROMPT_BY_MODE:
@@ -937,6 +1007,7 @@ def map_to_oneearth(
             emit_per_level=emit_per_level,
             read_from_cache=read_from_cache,
             write_to_cache=write_to_cache,
+            match_schema=match_schema,
         )
         if recover_unmatched:
             # Default top-level column + category choices from the level spec +
@@ -964,6 +1035,7 @@ def map_to_oneearth(
                 descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
                 confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
                 read_from_cache=read_from_cache, write_to_cache=write_to_cache,
+                match_schema=match_schema,
             )
 
     collapsed_df = collapse_to_one_row_per_uid(per_row_df, id_col=id_col)
@@ -974,6 +1046,7 @@ def _walk_recovered_entities(
     per_row_df: pd.DataFrame, *, session, tables, system_prompt, id_col, name_col,
     text_col, model, descent_fanout_cap, max_workers, confidence_threshold,
     emit_per_level, read_from_cache=True, write_to_cache=True,
+    match_schema: type[BaseModel] | None = None,
 ) -> pd.DataFrame:
     """Seed the walk at each recovery-recovered entity's pillar and descend.
 
@@ -1020,6 +1093,7 @@ def _walk_recovered_entities(
         confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
         seed_col=recovered_col,
         read_from_cache=read_from_cache, write_to_cache=write_to_cache,
+        match_schema=match_schema,
     )
 
     kept = per_row_df[~per_row_df[id_col].isin(rec_ids)]

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -24,21 +24,23 @@ used here for now.
 
 High-level usage
 ----------------
-    from openai import OpenAI
+    from vdl_tools.shared_tools.database_cache.database_utils import get_session
     from oe_hierarchical_taxonomy_mapping import map_to_oneearth
 
-    client = OpenAI(api_key=...)
-    per_row_df, collapsed_df = map_to_oneearth(
-        entities=my_dataframe,
-        id_col="uid",
-        name_col="Name",
-        text_col="Description",
-        client=client,
-    )
+    with get_session() as session:
+        per_row_df, collapsed_df = map_to_oneearth(
+            entities=my_dataframe,
+            id_col="uid",
+            name_col="Name",
+            text_col="Description",
+            session=session,
+        )
 
-The library re-exports ``build_system_prompt``, ``classify_entities``,
-``classify_entity`` from the generic engine for callers that want to
-drive the walk themselves with custom level specs / prompts.
+The library re-exports ``build_system_prompt`` and ``classify_entities``
+from the generic engine for callers that want to drive the walk
+themselves with custom level specs / prompts. All OpenAI calls flow
+through the SQL prompt/response cache — see
+``hierarchical_taxonomy_mapping``'s "Caching" docstring section.
 """
 
 from __future__ import annotations
@@ -47,13 +49,11 @@ import re
 from pathlib import Path
 
 import pandas as pd
-from openai import OpenAI
 
 import vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping as _htm
 from vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping import (
     build_system_prompt,
     classify_entities,
-    classify_entity,
 )
 
 
@@ -785,8 +785,9 @@ def build_recovery_scope_prompt(taxonomy_path: Path | None = None) -> str:
         + "Decide whether the organization's OWN work is in scope for any "
         "pillar above (an implicit climate mechanism is acceptable; an "
         "incidental co-benefit of otherwise out-of-scope work is not). "
-        "Return JSON: {\"in_scope\": true|false, \"pillar\": \"<exact pillar "
-        "name or null>\", \"reason\": \"<one sentence>\"}."
+        "Return JSON: {\"in_scope\": true|false, \"category\": \"<exact "
+        "pillar name from the list above, or null if not in scope>\", "
+        "\"reason\": \"<one sentence>\"}."
     )
 
 
@@ -796,7 +797,7 @@ def map_to_oneearth(
     id_col: str,
     name_col: str,
     text_col: str,
-    client: OpenAI,
+    session,
     model: str = MODEL,
     max_workers: int = DEFAULT_WORKERS,
     taxonomy_path: Path | None = None,
@@ -809,6 +810,7 @@ def map_to_oneearth(
     recovery_model: str = "gpt-4.1-mini",
     recovery_scope_prompt: str | None = None,
     walk_recovered: bool = False,
+    use_cached_result: bool = True,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Classify a DataFrame of entities against the One Earth taxonomy.
 
@@ -831,15 +833,20 @@ def map_to_oneearth(
     text_col
         Column with the entity description. The LLM matches against the
         text in this column.
-    client
-        An ``openai.OpenAI`` client. Caller supplies it so this library
-        does not depend on a project-specific config-file location.
+    session
+        SQLAlchemy session used by the SQL prompt/response cache. Build
+        via ``vdl_tools.shared_tools.database_cache.database_utils.
+        get_session``; the caller's ``with get_session() as session:``
+        block scopes the transaction.
     model
         OpenAI model id. Default ``MODEL`` (currently ``gpt-5.4-nano``).
     max_workers
-        Thread pool size for parallel classification. The hierarchical
-        walk is I/O-bound on the OpenAI API; large pools (16, 32, 64)
-        are fine. Use 1 for a single-threaded debug path.
+        Concurrency cap for the cache's API worker pool, applied per
+        level batch. The hierarchical walk is I/O-bound on the OpenAI
+        API; large pools (16, 32, 64) are fine.
+    use_cached_result
+        When False, bypass cached rows and re-issue every API call;
+        the new responses overwrite cache entries. Default True.
     taxonomy_path
         Optional override for the taxonomy xlsx. Defaults to
         ``find_latest_taxonomy()`` which picks the latest VDL-edited
@@ -916,7 +923,7 @@ def map_to_oneearth(
             system_prompt = _PROMPT_BY_MODE[prompt_mode]
 
     per_row_df = classify_entities(
-        client=client,
+        session=session,
         tables=tables,
         levels=ONEEARTH_LEVELS,
         system_prompt=system_prompt,
@@ -929,13 +936,14 @@ def map_to_oneearth(
         max_workers=max_workers,
         confidence_threshold=confidence_threshold,
         emit_per_level=emit_per_level,
+        use_cached_result=use_cached_result,
     )
     if recover_unmatched:
         # Default top-level column + category choices from the level spec +
         # tables; override only the scope prompt with the OE-specific rich one.
         per_row_df = _htm.recover_unmatched(
             per_row_df,
-            client=client,
+            session=session,
             model=recovery_model,
             id_col=id_col,
             name_col=name_col,
@@ -945,14 +953,16 @@ def map_to_oneearth(
             scope_prompt=recovery_scope_prompt or build_recovery_scope_prompt(
                 taxonomy_path),
             max_workers=max_workers,
+            use_cached_result=use_cached_result,
         )
 
     if walk_recovered:
         per_row_df = _walk_recovered_entities(
-            per_row_df, client=client, tables=tables, system_prompt=system_prompt,
+            per_row_df, session=session, tables=tables, system_prompt=system_prompt,
             id_col=id_col, name_col=name_col, text_col=text_col, model=model,
             descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
             confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
+            use_cached_result=use_cached_result,
         )
 
     collapsed_df = collapse_to_one_row_per_uid(per_row_df, id_col=id_col)
@@ -960,9 +970,9 @@ def map_to_oneearth(
 
 
 def _walk_recovered_entities(
-    per_row_df: pd.DataFrame, *, client, tables, system_prompt, id_col, name_col,
+    per_row_df: pd.DataFrame, *, session, tables, system_prompt, id_col, name_col,
     text_col, model, descent_fanout_cap, max_workers, confidence_threshold,
-    emit_per_level,
+    emit_per_level, use_cached_result=True,
 ) -> pd.DataFrame:
     """Seed the walk at each recovery-recovered entity's pillar and descend.
 
@@ -1002,12 +1012,12 @@ def _walk_recovered_entities(
                   .drop(columns=[c for c in class_cols if c in per_row_df.columns]))
 
     seeded = classify_entities(
-        client=client, tables=tables, levels=ONEEARTH_LEVELS,
+        session=session, tables=tables, levels=ONEEARTH_LEVELS,
         system_prompt=system_prompt, entities=seed_input, id_col=id_col,
         name_col=name_col, text_col=text_col, model=model,
         descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
         confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
-        seed_col=recovered_col,
+        seed_col=recovered_col, use_cached_result=use_cached_result,
     )
 
     kept = per_row_df[~per_row_df[id_col].isin(rec_ids)]
@@ -1041,5 +1051,4 @@ __all__ = [
     # Engine re-exports
     "build_system_prompt",
     "classify_entities",
-    "classify_entity",
 ]

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -45,6 +45,7 @@ through the SQL prompt/response cache — see
 
 from __future__ import annotations
 
+import contextlib
 import re
 from pathlib import Path
 from typing import Literal
@@ -978,7 +979,10 @@ def map_to_oneearth(
         SQLAlchemy session used by the SQL prompt/response cache. Build
         via ``vdl_tools.shared_tools.database_cache.database_utils.
         get_session``; the caller's ``with get_session() as session:``
-        block scopes the transaction.
+        block scopes the transaction and remains open and owned by the
+        caller (this function never commits or closes a session it did
+        not create). When ``None`` (default), a session is opened and
+        closed internally for the duration of the call.
     model
         OpenAI model id. Default ``MODEL`` (currently ``gpt-5.4-nano``).
     max_workers
@@ -1103,7 +1107,15 @@ def map_to_oneearth(
         else:
             system_prompt = _PROMPT_BY_MODE[prompt_mode]
 
-    with get_session(session=session) as session:
+    # Own the session lifecycle only when the caller didn't supply one.
+    # get_session() force-commits and closes the session it yields, so
+    # wrapping a caller-owned session here would surprise-commit and close
+    # it out from under the caller's own `with get_session()` block. When
+    # the caller passed a session, use it directly and leave commit/close
+    # to them; classify_entities / recover_unmatched commit internally.
+    owns_session = session is None
+    session_cm = get_session() if owns_session else contextlib.nullcontext(session)
+    with session_cm as session:
         per_row_df = classify_entities(
             session=session,
             tables=tables,

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -951,6 +951,7 @@ def map_to_oneearth(
     walk_recovered: bool = False,
     read_from_cache: bool = True,
     write_to_cache: bool = True,
+    filter_by_model: bool = True,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Classify a DataFrame of entities against the One Earth taxonomy.
 
@@ -990,6 +991,19 @@ def map_to_oneearth(
     write_to_cache
         When False, leave the cache untouched (read-only / passthrough).
         Default True.
+    filter_by_model
+        When True (default), cache rows are scoped by model name, so the
+        same taxonomy + prompt classified under different models (e.g.
+        ``gpt-5.4-nano`` vs ``gpt-4.1``) get separate cache entries. This
+        is the safe default for the A/B model-comparison workflow this
+        module supports: with ``False`` a second run under a different
+        model would silently reuse the first model's cached answers,
+        corrupting the comparison. Threaded into the classification walk,
+        the recovery pass, and the seeded re-walk so all three isolate by
+        model consistently. Flipping this to True costs nothing on
+        same-model re-runs — the cache's composite PK always stamps the
+        model on write, so existing rows still hit; only cross-model
+        reuse (which you want to avoid) becomes a miss.
     taxonomy_path
         Path to the taxonomy xlsx. If omitted, ``taxonomy_dir`` must be
         provided and the latest ``OE Solutions Terms *VDL.xlsx`` found in
@@ -1107,6 +1121,7 @@ def map_to_oneearth(
             read_from_cache=read_from_cache,
             write_to_cache=write_to_cache,
             match_schema=match_schema,
+            filter_by_model=filter_by_model,
         )
         if recover_unmatched:
             # Default top-level column + category choices from the level spec +
@@ -1125,6 +1140,7 @@ def map_to_oneearth(
                 max_workers=max_workers,
                 read_from_cache=read_from_cache,
                 write_to_cache=write_to_cache,
+                filter_by_model=filter_by_model,
             )
 
         if walk_recovered:
@@ -1134,7 +1150,7 @@ def map_to_oneearth(
                 descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
                 confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
                 read_from_cache=read_from_cache, write_to_cache=write_to_cache,
-                match_schema=match_schema,
+                match_schema=match_schema, filter_by_model=filter_by_model,
             )
 
     collapsed_df = collapse_to_one_row_per_uid(per_row_df, id_col=id_col)
@@ -1145,7 +1161,7 @@ def _walk_recovered_entities(
     per_row_df: pd.DataFrame, *, session, tables, system_prompt, id_col, name_col,
     text_col, model, descent_fanout_cap, max_workers, confidence_threshold,
     emit_per_level, read_from_cache=True, write_to_cache=True,
-    match_schema: type[BaseModel] | None = None,
+    match_schema: type[BaseModel] | None = None, filter_by_model: bool = True,
 ) -> pd.DataFrame:
     """Seed the walk at each recovery-recovered entity's pillar and descend.
 
@@ -1192,7 +1208,7 @@ def _walk_recovered_entities(
         confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
         seed_col=recovered_col,
         read_from_cache=read_from_cache, write_to_cache=write_to_cache,
-        match_schema=match_schema,
+        match_schema=match_schema, filter_by_model=filter_by_model,
     )
 
     kept = per_row_df[~per_row_df[id_col].isin(rec_ids)]

--- a/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py
@@ -55,18 +55,12 @@ from vdl_tools.shared_tools.taxonomy_mapping.hierarchical_taxonomy_mapping impor
     build_system_prompt,
     classify_entities,
 )
+from vdl_tools.shared_tools.database_cache.database_utils import get_session
 
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-
-# TODO: relativize SHARED_TAXONOMY_DIR via vdl_tools.shared_tools.project_config
-# when this file moves to vdl_tools/shared_tools/taxonomy_mapping/.
-SHARED_TAXONOMY_DIR = Path(
-    "/Users/rjw/Dropbox/VDL/shared-data-clean/data/taxonomies/oneearth"
-)
-
 MODEL = "gpt-5.4-nano"
 DESCENT_FANOUT_CAP = 3
 DEFAULT_WORKERS = 32  # I/O-bound on the OpenAI API; large pools are fine.
@@ -87,7 +81,7 @@ PILLAR_DETAIL_SHEETS = (
 # ---------------------------------------------------------------------------
 
 def find_latest_taxonomy(
-    taxonomy_dir: Path = SHARED_TAXONOMY_DIR,
+    taxonomy_dir: Path,
 ) -> Path:
     """Return the latest VDL-edited OE Solutions Terms xlsx in ``taxonomy_dir``.
 
@@ -797,7 +791,7 @@ def map_to_oneearth(
     id_col: str,
     name_col: str,
     text_col: str,
-    session,
+    session=None,
     model: str = MODEL,
     max_workers: int = DEFAULT_WORKERS,
     taxonomy_path: Path | None = None,
@@ -810,7 +804,8 @@ def map_to_oneearth(
     recovery_model: str = "gpt-4.1-mini",
     recovery_scope_prompt: str | None = None,
     walk_recovered: bool = False,
-    use_cached_result: bool = True,
+    read_from_cache: bool = True,
+    write_to_cache: bool = True,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Classify a DataFrame of entities against the One Earth taxonomy.
 
@@ -844,9 +839,12 @@ def map_to_oneearth(
         Concurrency cap for the cache's API worker pool, applied per
         level batch. The hierarchical walk is I/O-bound on the OpenAI
         API; large pools (16, 32, 64) are fine.
-    use_cached_result
-        When False, bypass cached rows and re-issue every API call;
-        the new responses overwrite cache entries. Default True.
+    read_from_cache
+        When False, bypass cached rows and re-issue every API call
+        (force-refresh). Default True.
+    write_to_cache
+        When False, leave the cache untouched (read-only / passthrough).
+        Default True.
     taxonomy_path
         Optional override for the taxonomy xlsx. Defaults to
         ``find_latest_taxonomy()`` which picks the latest VDL-edited
@@ -922,48 +920,51 @@ def map_to_oneearth(
         else:
             system_prompt = _PROMPT_BY_MODE[prompt_mode]
 
-    per_row_df = classify_entities(
-        session=session,
-        tables=tables,
-        levels=ONEEARTH_LEVELS,
-        system_prompt=system_prompt,
-        entities=entities,
-        id_col=id_col,
-        name_col=name_col,
-        text_col=text_col,
-        model=model,
-        descent_fanout_cap=descent_fanout_cap,
-        max_workers=max_workers,
-        confidence_threshold=confidence_threshold,
-        emit_per_level=emit_per_level,
-        use_cached_result=use_cached_result,
-    )
-    if recover_unmatched:
-        # Default top-level column + category choices from the level spec +
-        # tables; override only the scope prompt with the OE-specific rich one.
-        per_row_df = _htm.recover_unmatched(
-            per_row_df,
+    with get_session(session=session) as session:
+        per_row_df = classify_entities(
             session=session,
-            model=recovery_model,
+            tables=tables,
+            levels=ONEEARTH_LEVELS,
+            system_prompt=system_prompt,
+            entities=entities,
             id_col=id_col,
             name_col=name_col,
             text_col=text_col,
-            levels=ONEEARTH_LEVELS,
-            tables=tables,
-            scope_prompt=recovery_scope_prompt or build_recovery_scope_prompt(
-                taxonomy_path),
+            model=model,
+            descent_fanout_cap=descent_fanout_cap,
             max_workers=max_workers,
-            use_cached_result=use_cached_result,
+            confidence_threshold=confidence_threshold,
+            emit_per_level=emit_per_level,
+            read_from_cache=read_from_cache,
+            write_to_cache=write_to_cache,
         )
+        if recover_unmatched:
+            # Default top-level column + category choices from the level spec +
+            # tables; override only the scope prompt with the OE-specific rich one.
+            per_row_df = _htm.recover_unmatched(
+                per_row_df,
+                session=session,
+                model=recovery_model,
+                id_col=id_col,
+                name_col=name_col,
+                text_col=text_col,
+                levels=ONEEARTH_LEVELS,
+                tables=tables,
+                scope_prompt=recovery_scope_prompt or build_recovery_scope_prompt(
+                    taxonomy_path),
+                max_workers=max_workers,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
+            )
 
-    if walk_recovered:
-        per_row_df = _walk_recovered_entities(
-            per_row_df, session=session, tables=tables, system_prompt=system_prompt,
-            id_col=id_col, name_col=name_col, text_col=text_col, model=model,
-            descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
-            confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
-            use_cached_result=use_cached_result,
-        )
+        if walk_recovered:
+            per_row_df = _walk_recovered_entities(
+                per_row_df, session=session, tables=tables, system_prompt=system_prompt,
+                id_col=id_col, name_col=name_col, text_col=text_col, model=model,
+                descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
+                confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
+                read_from_cache=read_from_cache, write_to_cache=write_to_cache,
+            )
 
     collapsed_df = collapse_to_one_row_per_uid(per_row_df, id_col=id_col)
     return per_row_df, collapsed_df
@@ -972,7 +973,7 @@ def map_to_oneearth(
 def _walk_recovered_entities(
     per_row_df: pd.DataFrame, *, session, tables, system_prompt, id_col, name_col,
     text_col, model, descent_fanout_cap, max_workers, confidence_threshold,
-    emit_per_level, use_cached_result=True,
+    emit_per_level, read_from_cache=True, write_to_cache=True,
 ) -> pd.DataFrame:
     """Seed the walk at each recovery-recovered entity's pillar and descend.
 
@@ -1017,7 +1018,8 @@ def _walk_recovered_entities(
         name_col=name_col, text_col=text_col, model=model,
         descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
         confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
-        seed_col=recovered_col, use_cached_result=use_cached_result,
+        seed_col=recovered_col,
+        read_from_cache=read_from_cache, write_to_cache=write_to_cache,
     )
 
     kept = per_row_df[~per_row_df[id_col].isin(rec_ids)]
@@ -1052,3 +1054,20 @@ __all__ = [
     "build_system_prompt",
     "classify_entities",
 ]
+
+
+if __name__ == "__main__":
+    taxonomy_dir = find_latest_taxonomy(Path("../shared-data-clean/data/taxonomies/oneearth"))
+    entities = pd.DataFrame([
+        {"id": 1, "name": "CCS", "description": "CCS is a project developer focusing on building carbon capture and storage facilities."},
+        {"id": 2, "name": "Electric Semis", "description": "Electric Semis is an auto manufacturer focusing on building electric semi-trucks. They also build battery storage systems."},
+        {"id": 3, "name": "Forest Defense Fund", "description": "Forest Defense Fund is a non-profit organization focusing on protecting forests and wildlife."},
+    ])
+    results = map_to_oneearth(
+        entities=entities,
+        taxonomy_path=taxonomy_dir,
+        id_col="id",
+        name_col="name",
+        text_col="description",
+    )
+    print(results)

--- a/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
@@ -20,14 +20,15 @@ become "nullable required" — the model is forced to emit *something* for
 each, even when the prompt didn't ask. For prompts without modes (e.g.
 ED-tracker), that can spuriously trigger the engine's indirect-fanout-stop
 when the model guesses ``"indirect"``. Drivers that want tight control
-should define their own minimal Pydantic class and pass it as
-``response_model`` to ``TaxonomyMatchCache`` (and as ``match_schema`` to
-``build_system_prompt`` / ``classify_entities``).
+should define their own Pydantic class (embedding per-field guidance via
+``Field(description=...)`` and selection-level guidance on the response
+class's docstring) and pass it as ``response_model`` to
+``TaxonomyMatchCache`` / as ``match_schema`` to ``classify_entities``.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
 from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
@@ -36,26 +37,67 @@ from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODE
 class Match(BaseModel):
     """One candidate match at a single taxonomy level.
 
-    ``index`` is 1-based and refers to the candidate's position in the
-    numbered list rendered in the user prompt — the engine validates it
-    against the candidate count in Python (out-of-range / index=0 / duplicate
-    indices are dropped with a warning, matching the pre-cache behavior).
+    The engine validates ``index`` against the candidate count in Python
+    (out-of-range / index=0 / duplicate indices are dropped with a warning,
+    matching the pre-cache behavior).
 
     ``mode_of_operation`` and ``confidence`` stay loosely-typed strings /
-    floats so the schema accepts responses from prompts built without modes
-    or without ``include_confidence=True``. The engine normalizes unknown
-    modes to ``""`` and clamps confidence into [0, 1].
+    floats so the default schema accepts responses from prompts built
+    without modes or confidence. The engine normalizes unknown modes to
+    ``""`` and clamps confidence into [0, 1].
     """
 
-    index: int
-    mode_of_operation: str | None = None
-    evidence: str = ""
-    reason: str = ""
-    confidence: float | None = None
+    index: int = Field(
+        description=(
+            "The 1-based position of the matched candidate in the numbered "
+            "candidate list shown in the user prompt. Never return 0 or an "
+            "out-of-range index — to indicate no match, return `matches: []`."
+        ),
+    )
+    mode_of_operation: str | None = Field(
+        default=None,
+        description=(
+            "How the entity relates to the matched candidate. Use the "
+            "values defined by the project's mode-of-operation field on "
+            "its own Match subclass. Leave null when the prompt does not "
+            "ask for a mode."
+        ),
+    )
+    evidence: str = Field(
+        default="",
+        description=(
+            "Phrase(s) from the description that support the match. Quote "
+            "or closely paraphrase the supporting language. If no language "
+            "in the description supports the candidate, omit the match — "
+            "do not invent evidence."
+        ),
+    )
+    reason: str = Field(
+        default="",
+        description=(
+            "One sentence explaining how the evidence maps to the "
+            "candidate's definition."
+        ),
+    )
+    confidence: float | None = Field(
+        default=None,
+        description=(
+            "Confidence in [0, 1] that the description supports this match. "
+            "Leave null when the prompt does not ask for a confidence."
+        ),
+    )
 
 
 class MatchesResponse(BaseModel):
-    """Top-level response shape returned by the per-level match call."""
+    """Default match-set response.
+
+    Selection behavior: emit only the matches that the description clearly
+    supports — self-filter weak candidates. Drivers whose schema enables a
+    ``confidence`` field should subclass this and override the docstring to
+    say *emit every plausible candidate with low confidence; let downstream
+    threshold filter* — that selection rule is what tells the model to
+    score weak matches instead of dropping them.
+    """
 
     matches: list[Match] = []
 
@@ -87,9 +129,10 @@ class TaxonomyMatchCache(InstructorPRC):
     ``response_model`` defaults to ``MatchesResponse``. Drivers that want
     tighter control over what the model emits (e.g. a schema without
     ``mode_of_operation`` for projects that don't use modes) should pass
-    their own Pydantic class — the same one they handed to
-    ``build_system_prompt(match_schema=...)`` so prompt and structural
-    enforcement stay in sync.
+    their own Pydantic class. The model sees the class's Field
+    descriptions and class docstring via the schema JSON that
+    ``InstructorPRC`` appends to the prompt, so per-field guidance and
+    selection-level guidance both live on the schema itself.
     """
 
     def __init__(

--- a/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
@@ -13,12 +13,16 @@ Two thin ``InstructorPRC`` subclasses + their Pydantic response schemas:
 Both classes inherit ``bulk_get_cache_or_run`` from ``InstructorPRC``; the
 hierarchical mapping engine drives them one bulk call per level.
 
-The Pydantic schemas are intentionally permissive on optional fields
-(``mode_of_operation``, ``confidence``) so the same schema works whether or
-not the system prompt was built with modes / confidence enabled — when the
-prompt does not ask for them, the model returns ``null`` and the engine's
-downstream cleaning normalizes that to the existing "empty mode" /
-"no confidence" behavior.
+The default ``MatchesResponse`` is permissive on optional fields
+(``mode_of_operation``, ``confidence``) so it accepts responses from any
+prompt. **But** under OpenAI strict-mode structured output, those fields
+become "nullable required" — the model is forced to emit *something* for
+each, even when the prompt didn't ask. For prompts without modes (e.g.
+ED-tracker), that can spuriously trigger the engine's indirect-fanout-stop
+when the model guesses ``"indirect"``. Drivers that want tight control
+should define their own minimal Pydantic class and pass it as
+``response_model`` to ``TaxonomyMatchCache`` (and as ``match_schema`` to
+``build_system_prompt`` / ``classify_entities``).
 """
 
 from __future__ import annotations
@@ -79,6 +83,13 @@ class TaxonomyMatchCache(InstructorPRC):
     ``given_id`` is built by the engine from
     ``(entity_id, parent_path, level_name)``, ``text_id`` hashes the
     user-message body (entity name/description + candidate list).
+
+    ``response_model`` defaults to ``MatchesResponse``. Drivers that want
+    tighter control over what the model emits (e.g. a schema without
+    ``mode_of_operation`` for projects that don't use modes) should pass
+    their own Pydantic class — the same one they handed to
+    ``build_system_prompt(match_schema=...)`` so prompt and structural
+    enforcement stay in sync.
     """
 
     def __init__(
@@ -88,12 +99,13 @@ class TaxonomyMatchCache(InstructorPRC):
         model: str = DEFAULT_MODEL,
         store_results: bool = True,
         filter_by_model: bool = False,
+        response_model: type[BaseModel] = MatchesResponse,
     ):
         super().__init__(
             session=session,
             prompt_str=system_prompt,
             prompt_name="hierarchical_taxonomy_match",
-            response_model=MatchesResponse,
+            response_model=response_model,
             model=model,
             filter_by_model=filter_by_model,
             store_results=store_results,

--- a/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
@@ -1,0 +1,128 @@
+"""SQL-backed prompt/response cache classes for hierarchical taxonomy mapping.
+
+Two thin ``InstructorPRC`` subclasses + their Pydantic response schemas:
+
+- ``TaxonomyMatchCache`` — per-level match call used by ``classify_entities``.
+  Asks the model which candidate node(s) at a given taxonomy level the
+  entity's description supports. Response: ``MatchesResponse``.
+
+- ``ScopeRecoveryCache`` — second-stage scope check used by
+  ``recover_unmatched`` for entities the top-down walk left empty.
+  Response: ``ScopeDecision``.
+
+Both classes inherit ``bulk_get_cache_or_run`` from ``InstructorPRC``; the
+hierarchical mapping engine drives them one bulk call per level.
+
+The Pydantic schemas are intentionally permissive on optional fields
+(``mode_of_operation``, ``confidence``) so the same schema works whether or
+not the system prompt was built with modes / confidence enabled — when the
+prompt does not ask for them, the model returns ``null`` and the engine's
+downstream cleaning normalizes that to the existing "empty mode" /
+"no confidence" behavior.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from vdl_tools.shared_tools.openai.prompt_response_cache_instructor import InstructorPRC
+from vdl_tools.shared_tools.openai.prompt_response_cache_sql import DEFAULT_MODEL
+
+
+class Match(BaseModel):
+    """One candidate match at a single taxonomy level.
+
+    ``index`` is 1-based and refers to the candidate's position in the
+    numbered list rendered in the user prompt — the engine validates it
+    against the candidate count in Python (out-of-range / index=0 / duplicate
+    indices are dropped with a warning, matching the pre-cache behavior).
+
+    ``mode_of_operation`` and ``confidence`` stay loosely-typed strings /
+    floats so the schema accepts responses from prompts built without modes
+    or without ``include_confidence=True``. The engine normalizes unknown
+    modes to ``""`` and clamps confidence into [0, 1].
+    """
+
+    index: int
+    mode_of_operation: str | None = None
+    evidence: str = ""
+    reason: str = ""
+    confidence: float | None = None
+
+
+class MatchesResponse(BaseModel):
+    """Top-level response shape returned by the per-level match call."""
+
+    matches: list[Match] = []
+
+
+class ScopeDecision(BaseModel):
+    """Second-stage scope-recovery response.
+
+    ``category`` is the universal field name for the recovered top-level
+    node (e.g. a Pillar). Older free-form prompts that emitted ``pillar``
+    must be rewritten to emit ``category`` — the structured-output schema
+    is the source of truth.
+    """
+
+    in_scope: bool
+    category: str | None = None
+    reason: str = ""
+
+
+class TaxonomyMatchCache(InstructorPRC):
+    """Per-level taxonomy match cache.
+
+    Construct once per (system_prompt, model); reuse across every level of
+    the walk. Cache rows are keyed by (prompt_id, given_id, text_id):
+    ``prompt_id`` is derived from the system prompt + the response schema,
+    ``given_id`` is built by the engine from
+    ``(entity_id, parent_path, level_name)``, ``text_id`` hashes the
+    user-message body (entity name/description + candidate list).
+    """
+
+    def __init__(
+        self,
+        session,
+        system_prompt: str,
+        model: str = DEFAULT_MODEL,
+        store_results: bool = True,
+        filter_by_model: bool = False,
+    ):
+        super().__init__(
+            session=session,
+            prompt_str=system_prompt,
+            prompt_name="hierarchical_taxonomy_match",
+            response_model=MatchesResponse,
+            model=model,
+            filter_by_model=filter_by_model,
+            store_results=store_results,
+        )
+
+
+class ScopeRecoveryCache(InstructorPRC):
+    """Second-stage scope-recovery cache for ``recover_unmatched``.
+
+    One call per unmatched entity; ``given_id`` is the entity's id, ``text``
+    is the entity name + description. The scope prompt must instruct the
+    model to populate ``category`` with the exact name of an in-scope
+    top-level node (or null), matching the ``ScopeDecision`` schema.
+    """
+
+    def __init__(
+        self,
+        session,
+        scope_prompt: str,
+        model: str = DEFAULT_MODEL,
+        store_results: bool = True,
+        filter_by_model: bool = False,
+    ):
+        super().__init__(
+            session=session,
+            prompt_str=scope_prompt,
+            prompt_name="hierarchical_taxonomy_scope_recovery",
+            response_model=ScopeDecision,
+            model=model,
+            filter_by_model=filter_by_model,
+            store_results=store_results,
+        )

--- a/vdl_tools/shared_tools/taxonomy_mapping/uncached_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/uncached_hierarchical_taxonomy_mapping.py
@@ -1,0 +1,1176 @@
+"""
+Hierarchical Taxonomy Mapping — general library
+================================================
+
+Reusable utilities for matching a list of entities (companies/organizations)
+against a multi-level hierarchical taxonomy via an OpenAI chat-completion
+model.
+
+Algorithm
+---------
+For each entity we walk the taxonomy top-down. At each level we send the
+entity description together with the candidate nodes (name + definition)
+for that level to the model and ask for the best match(es):
+
+    - if a single best match is returned, we descend to that node's
+      children at the next level;
+    - if the model returns multiple "best" matches, the entity is treated
+      as a generalist at this level and (subject to the descent fan-out
+      cap) we descend into each match.
+
+The walk yields one record per leaf in the resulting match tree — a leaf
+is a match that was either at the deepest level, had no children matched,
+truncated by the descent fan-out cap, or (when the prompt produces a
+``mode_of_operation`` field) tagged ``indirect`` alongside other siblings.
+
+This module is taxonomy-agnostic. Callers (driver scripts) supply:
+
+    * a level spec (see below),
+    * a system prompt string describing the matching task — assemble one
+      with ``build_system_prompt`` (see "System prompt" below),
+    * a taxonomy xlsx whose sheet names align with the level spec,
+    * an entities DataFrame with id / name / text columns.
+
+See ``drawdown_hierarchical_taxonomy_mapping.py`` for an example driver.
+
+Level Spec
+----------
+The taxonomy hierarchy is described as a list of dicts (one per level,
+ordered shallowest-first). Each dict has these fields:
+
+    {
+        "idx":                int,        # 0-based depth
+        "name":               str,        # human label used in the prompt and
+                                          # as the deepest_match value
+        "sheet":              str,        # excel sheet name
+        "key_col":            str,        # name column rendered to the LLM
+        "output_col":         str,        # column name in the per-row dataframe
+        "parent_filters":     list[str],  # cols this level uses to filter by parent path
+        "child_filter_col":   str,        # col on a CHILD's row that points back to me
+                                          # (defaults to key_col)
+        "child_filter_value_col": str,    # col on MY row whose value populates that filter
+                                          # (defaults to key_col)
+    }
+
+Defaults for ``child_filter_col`` and ``child_filter_value_col`` are
+applied by ``normalize_levels``; most levels need not set them.
+
+System prompt
+-------------
+The ``system_prompt`` passed to ``classify_entities`` can be any string,
+but in practice you should build it with ``build_system_prompt``, which
+assembles a generic skeleton (task framing, JSON output schema, eight
+numbered matching-rule slots, output constraints) and lets you customize
+the parts that vary per taxonomy.
+
+The skeleton was extracted from the Drawdown driver, so the rule set
+and structure reflect what worked there. The eight rule keys, in order,
+are listed in ``PROMPT_RULE_KEYS``:
+
+    1. ``domain_relevance``  — when does the description support a match
+    2. ``evidence_only``     — match on description text, not entity name
+    3. ``cross_sector``      — keep the entity in its own category
+    4. ``specificity``       — broad themes don't justify narrow children
+    5. ``multiple_matches``  — when to select more than one sibling
+    6. ``qualifier_lock``    — qualifiers in candidate names are mandatory
+    7. ``prominence``        — top levels need core-line-of-business
+    8. ``advocacy_depth``    — match depth must reflect evidence scope
+
+Each rule has a generic default that contains no domain examples
+(except rules 2 and 5, whose examples — name-vs-evidence and the "clean
+energy" ambiguity — transfer to any taxonomy). Override any subset by
+passing ``rules={"<key>": "<full body without leading number>"}``.
+
+Three layers of customization, from least to most invasive:
+
+    1. ``domain_intro`` (required) — opening paragraph framing what the
+       taxonomy classifies. Replaces the climate-mitigation framing
+       used by Drawdown.
+    2. ``modes`` (optional) — list of ``{"name", "definition"}`` dicts.
+       When provided, ``mode_of_operation`` appears in the JSON schema
+       and a "Mode of operation" section follows the schema. When
+       ``None``, both are omitted entirely. The default rule bodies do
+       not reference modes; if your modes belong inside specific rules,
+       supply rule overrides for those rules (Drawdown does this for
+       ``prominence`` and ``advocacy_depth``).
+    3. ``rules`` (optional) — dict mapping any of the eight keys above
+       to a full override. Use this when a generic default's wording
+       isn't tight enough for your domain — typically because it needs
+       domain-specific examples or terminology that improves model
+       accuracy.
+
+The Drawdown driver demonstrates all three layers — see
+``DRAWDOWN_DOMAIN_INTRO``, ``DRAWDOWN_MODES``, and
+``DRAWDOWN_RULE_OVERRIDES`` in ``drawdown_hierarchical_taxonomy_mapping.py``.
+
+For a brand-new taxonomy with no special rules, the minimum is::
+
+    system_prompt = build_system_prompt(
+        levels=my_levels,
+        domain_intro="You are classifying X against a hierarchical taxonomy of Y...",
+    )
+
+Output schema
+-------------
+``classify_entities`` returns a flat per-row DataFrame. Columns:
+
+    [id_col, name_col, text_col]
+    + [other entity columns, in input order]
+    + [lvl["output_col"] for lvl in levels]
+    + ["deepest_match", "leaf_definition",
+       "mode_of_operation", "evidence", "reason"]
+
+One row per (entity, leaf) pair. Entities with no level-0 match still
+appear with all level columns null.
+
+``collapse_to_one_row_per_uid`` collapses that frame to one row per
+``id_col`` value with ``repr()``-encoded list cells per level.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+from openai import OpenAI
+
+
+# ---------------------------------------------------------------------------
+# OpenAI client
+# ---------------------------------------------------------------------------
+
+def build_openai_client(
+    config_paths: Path | Iterable[Path],
+) -> OpenAI:
+    """Read the API key from the first config.ini that exists; return a client.
+
+    ``config_paths`` may be a single Path or an iterable of Paths. The
+    function tries each in order, returning a client built from the first
+    one that exists and contains an ``[openai]`` section.
+    """
+    if isinstance(config_paths, Path):
+        config_paths = [config_paths]
+    cfg = configparser.ConfigParser()
+    for candidate in config_paths:
+        if candidate.exists():
+            cfg.read(candidate)
+            if cfg.has_section("openai"):
+                return OpenAI(api_key=cfg["openai"]["openai_api_key"])
+    raise RuntimeError(
+        f"Could not find an [openai] section in any of: "
+        f"{[str(p) for p in config_paths]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Level spec normalization
+# ---------------------------------------------------------------------------
+
+def normalize_levels(levels: list[dict]) -> list[dict]:
+    """Fill in defaults for ``child_filter_col`` / ``child_filter_value_col``.
+
+    Returns a new list — does not mutate the caller's spec.
+    """
+    out = []
+    for lvl in levels:
+        normalized = dict(lvl)
+        normalized.setdefault("child_filter_col", normalized["key_col"])
+        normalized.setdefault("child_filter_value_col", normalized["key_col"])
+        out.append(normalized)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy loading
+# ---------------------------------------------------------------------------
+
+def load_taxonomy(path: Path, levels: list[dict]) -> dict[int, pd.DataFrame]:
+    """Load each level of the taxonomy as a DataFrame, keyed by level index.
+
+    Rows missing the level's key column or ``Definition`` are dropped so
+    prompts stay clean.
+    """
+    tables: dict[int, pd.DataFrame] = {}
+    for lvl in levels:
+        df = pd.read_excel(path, sheet_name=lvl["sheet"])
+        df = df.dropna(subset=[lvl["key_col"], "Definition"]).reset_index(drop=True)
+        tables[lvl["idx"]] = df
+    return tables
+
+
+def candidates_for_level(
+    tables: dict[int, pd.DataFrame],
+    level: int,
+    parent_path: dict[str, str],
+) -> pd.DataFrame:
+    """Return candidate nodes at ``level`` that are children of ``parent_path``.
+
+    ``parent_path`` maps parent column name -> value, e.g.
+        {"Sector": "Electricity", "Cluster": "Shift Production"}.
+    """
+    df = tables[level]
+    for col, val in parent_path.items():
+        df = df[df[col] == val]
+    return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Prompting
+# ---------------------------------------------------------------------------
+
+# Ordered list of rule keys understood by ``build_system_prompt``. The
+# numbered rules in the assembled prompt appear in this order.
+PROMPT_RULE_KEYS: tuple[str, ...] = (
+    "domain_relevance",
+    "evidence_only",
+    "cross_sector",
+    "specificity",
+    "multiple_matches",
+    "qualifier_lock",
+    "prominence",
+    "advocacy_depth",
+)
+
+
+def _default_rule_bodies(levels: list[dict]) -> dict[str, str]:
+    """Generic rule defaults used by ``build_system_prompt``.
+
+    No domain examples appear in any rule body except rules 2 and 5,
+    whose name-vs-evidence and ambiguous-phrase examples transfer to
+    any taxonomy. Rule 7 references the first two level names from the
+    ``levels`` spec so the wording reads naturally for any hierarchy.
+    Rule bodies do NOT reference mode-of-operation; callers whose
+    domain uses modes should override ``prominence`` and
+    ``advocacy_depth`` to bring back mode-aware language.
+    """
+    top_name = levels[0]["name"] if len(levels) >= 1 else "top-level"
+    mid_name = levels[1]["name"] if len(levels) >= 2 else "second-level"
+    return {
+        "domain_relevance": (
+            "Domain relevance. Match a candidate when the description "
+            "names activities aligned with the candidate's definition. "
+            "The taxonomy already establishes the relevance mechanism "
+            "for each candidate — your job is to decide whether the "
+            "description names the activity, not to re-derive whether "
+            "it qualifies. When the description is too thin to commit "
+            "even at the top level, return `matches: []`."
+        ),
+        "evidence_only": (
+            "Evidence from the description only. Base every match on "
+            "specific language from the provided description — not on "
+            "the entity's name, reputation, or outside knowledge. Quote "
+            "or closely paraphrase that language in the `evidence` "
+            "field. The entity's NAME is not evidence: 'Prairie "
+            "Preservation Society' does not by itself support a "
+            "'Protect Grasslands' candidate unless the description "
+            "names grasslands, prairies, or that practice; 'Solar Co.' "
+            "does not support a solar candidate unless the description "
+            "names solar. If the only thing pointing at a candidate is "
+            "the name, return `matches: []`."
+        ),
+        "cross_sector": (
+            "No cross-category inference. Assign a node only if the "
+            "entity itself performs the activity at that node. An "
+            "entity that supplies an input or service used by another "
+            "category belongs to its own category, unless the "
+            "description says the entity also operates in the "
+            "destination category."
+        ),
+        "specificity": (
+            "Specificity must match the level. A candidate is "
+            "selectable only when the description names activity "
+            "specific enough to support it. Broad themes can support "
+            "top-level categories but are not sufficient for a narrower "
+            "child unless the description also names the specific "
+            "technology, process, material, or practice the child "
+            "covers. When in doubt, return `matches: []` and let the "
+            "walk stop one level higher."
+        ),
+        "multiple_matches": (
+            "Selecting multiple matches. Look at the specific phrase "
+            "you would cite as evidence — apply selection per phrase, "
+            "not per entity. Select every candidate whose technology "
+            "or practice is named by its own distinct phrase. Entities "
+            "doing several things may match several siblings. Do not "
+            "select a candidate when the phrase that would support it "
+            "is generic enough to fit multiple siblings (e.g. 'clean "
+            "energy' could be wind, solar, or nuclear). Return an "
+            "empty list when no candidate has specific supporting "
+            "evidence."
+        ),
+        "qualifier_lock": (
+            "Qualifier lock. Qualifiers in a candidate's name are "
+            "mandatory constraints, not flavor. If the description "
+            "identifies a different qualifier, do NOT select that "
+            "candidate. If the description is silent on the qualifier, "
+            "do NOT select — the candidate's qualifier must be "
+            "supported by the description. When no sibling's qualifier "
+            "matches the description, return an empty list at this "
+            "level."
+        ),
+        "prominence": (
+            f"Prominence at {top_name} and {mid_name} levels. At these "
+            "two levels, select only activities that are a core line "
+            "of business — a distinct area with multiple sentences, "
+            "listed among the entity's main offerings, or described as "
+            "a primary focus. A single incidental phrase ('also "
+            "supports X', 'including X', 'in addition to Y') about an "
+            "activity otherwise absent from the description is not "
+            "enough at these levels. At deeper levels, this threshold "
+            "does not apply for entities directly performing or "
+            "enabling the technology — a specifically named technology "
+            "or practice is sufficient even if briefly mentioned."
+        ),
+        "advocacy_depth": (
+            "Match depth must reflect evidence scope. A match must sit "
+            "at the level whose scope is supported by the description, "
+            "not at deeper levels the entity does not itself address. "
+            "The narrower the candidate, the more explicit the "
+            "supporting evidence must be."
+        ),
+    }
+
+
+_OUTPUT_CONSTRAINTS = (
+    "Output constraints:\n"
+    "- `index` must be the integer shown before a candidate in the "
+    "list. Indices are 1-based and must match a number actually shown "
+    "in the candidate list. Do not invent indices and do not return "
+    "names. To indicate no match, return `matches: []` — never return "
+    "index 0 or any index outside the listed range."
+)
+
+_TASK_FRAMING = (
+    "You will be given an entity description and a numbered list of "
+    "candidate nodes (name + definition) at a single level of the "
+    "hierarchy. Identify which node(s) the description shows the "
+    "entity is actually working on."
+)
+
+
+def build_system_prompt(
+    *,
+    levels: list[dict],
+    domain_intro: str,
+    modes: list[dict] | None = None,
+    rules: dict[str, str] | None = None,
+    include_confidence: bool = False,
+) -> str:
+    """Assemble a hierarchical-taxonomy classification system prompt.
+
+    Composes a generic skeleton — ``domain_intro``, task framing, JSON
+    output schema, an optional Mode-of-operation section, eight
+    matching-rule slots, and output constraints — with any caller-
+    supplied overrides. Each rule has a generic default that contains
+    no domain examples (except rules 2 and 5, whose examples transfer
+    to any taxonomy). Pass ``rules={"<key>": "<override text>"}`` to
+    replace any rule with domain-specific wording; missing keys keep
+    their generic default.
+
+    Parameters
+    ----------
+    levels
+        Same level-spec list passed to ``classify_entities``. The
+        ``name`` field on each spec is used in rule 7's "Prominence
+        at <top> and <mid> levels" wording.
+    domain_intro
+        Opening paragraph framing what the taxonomy classifies.
+    modes
+        Optional list of mode dicts, each with ``name`` and
+        ``definition``. When provided, ``mode_of_operation`` appears
+        in the JSON schema and a "Mode of operation" section follows
+        the schema. When ``None``, both are omitted entirely. The
+        default rule bodies do not reference modes; supply rule
+        overrides if mode-aware language belongs in your rules.
+    rules
+        Optional dict mapping any of the keys in ``PROMPT_RULE_KEYS``
+        to a full override body (without leading number). Missing
+        keys fall back to ``_default_rule_bodies(levels)``.
+    """
+    overrides = rules or {}
+
+    # Optional confidence field — when present, each match carries a
+    # 0-1 confidence and downstream code can threshold on it (see
+    # ``confidence_threshold``). Enabling it also changes the matching
+    # disposition: the model surfaces plausible-but-weak candidates with
+    # low confidence instead of self-filtering, so the threshold becomes a
+    # genuine bidirectional precision/recall knob.
+    conf_field = '"confidence": <number 0-1>, ' if include_confidence else ''
+
+    # JSON output schema — mode_of_operation included only when modes given.
+    if modes:
+        mode_union = " | ".join(f'"{m["name"]}"' for m in modes)
+        schema = (
+            '  {"matches": [{"index": <int>, '
+            f'"mode_of_operation": {mode_union}, '
+            + conf_field +
+            '"evidence": "<phrase(s) from the description that '
+            'support the match>", '
+            '"reason": "<how the evidence maps to the candidate '
+            'definition>"}]}'
+        )
+    else:
+        schema = (
+            '  {"matches": [{"index": <int>, '
+            + conf_field +
+            '"evidence": "<phrase(s) from the description that '
+            'support the match>", '
+            '"reason": "<how the evidence maps to the candidate '
+            'definition>"}]}'
+        )
+
+    # Optional mode-of-operation section.
+    if modes:
+        mode_lines = [
+            "Mode of operation — for each selected candidate, classify "
+            "HOW the entity relates to the matched candidate:"
+        ]
+        for m in modes:
+            mode_lines.append(f"- '{m['name']}': {m['definition']}")
+        mode_lines.append(
+            "Pick the mode that best fits the entity's primary "
+            "relationship to the matched candidate."
+        )
+        modes_section: str | None = "\n".join(mode_lines)
+    else:
+        modes_section = None
+
+    defaults = _default_rule_bodies(levels)
+    numbered_rules: list[str] = []
+    for i, key in enumerate(PROMPT_RULE_KEYS, start=1):
+        body = overrides.get(key, defaults[key])
+        numbered_rules.append(f"{i}. {body}")
+
+    parts: list[str] = [
+        domain_intro,
+        _TASK_FRAMING,
+        f"Return JSON of the form:\n{schema}",
+    ]
+    if modes_section is not None:
+        parts.append(modes_section)
+    parts.append("Matching rules:\n" + "\n".join(numbered_rules))
+    if include_confidence:
+        parts.append(
+            "Confidence. For each match, include a `confidence` in [0,1] "
+            "reflecting how strongly the description supports it (1 = the "
+            "description names the activity explicitly; lower = weaker or "
+            "more inferential support). Surface every candidate that "
+            "plausibly fits, including weak or uncertain ones with low "
+            "confidence — do not omit a plausible candidate just because "
+            "it is uncertain. A downstream threshold decides which to keep."
+        )
+    parts.append(_OUTPUT_CONSTRAINTS)
+
+    return "\n\n".join(parts)
+
+
+def format_candidates(candidates: pd.DataFrame, key_col: str) -> str:
+    """Render candidates as a numbered list of name + definition."""
+    lines = []
+    for i, row in candidates.iterrows():
+        name = str(row[key_col]).strip()
+        definition = str(row["Definition"]).strip()
+        lines.append(f"{i + 1}. {name}\n   Definition: {definition}")
+    return "\n\n".join(lines)
+
+
+def call_openai_match(
+    client: OpenAI,
+    system_prompt: str,
+    model: str,
+    entity_name: str,
+    entity_description: str,
+    level_name: str,
+    candidates: pd.DataFrame,
+    key_col: str,
+    confidence_threshold: float | None = None,
+) -> list[dict[str, str]]:
+    """Ask the model for the best candidate match(es) at this level.
+
+    When ``confidence_threshold`` is set, the system prompt is expected to
+    request a per-match ``confidence`` (build it with
+    ``build_system_prompt(include_confidence=True)``); matches whose
+    confidence is below the threshold are dropped. The threshold is the
+    precision/recall knob: lower keeps more (weak) matches, higher keeps
+    only strong ones. Missing/unparseable confidence defaults to 1.0 so a
+    non-confidence prompt behaves exactly as before.
+    """
+    user_prompt = (
+        f"Entity name: {entity_name}\n\n"
+        f"Entity description:\n{entity_description}\n\n"
+        f"Taxonomy level: {level_name}\n"
+        f"Candidate nodes at this level:\n\n"
+        f"{format_candidates(candidates, key_col)}"
+    )
+
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        response_format={"type": "json_object"},
+        temperature=0,
+    )
+
+    raw = resp.choices[0].message.content or "{}"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        print(f"  [warn] bad JSON at level {level_name}: {raw[:200]}")
+        return []
+
+    matches = data.get("matches", []) or []
+    n = len(candidates)
+    cleaned: list[dict[str, str]] = []
+    seen: set[int] = set()
+    for m in matches:
+        raw_idx = m.get("index")
+        try:
+            idx = int(raw_idx)
+        except (TypeError, ValueError):
+            print(f"  [warn] non-integer index at {level_name}: {raw_idx!r}")
+            continue
+        # Candidate list is rendered 1-based; convert to a 0-based row index.
+        # The prompt says to return `matches: []` for "no match", but some
+        # models still emit index 0 as a no-match signal — accept it silently.
+        if idx == 0:
+            continue
+        if not (1 <= idx <= n):
+            print(f"  [warn] out-of-range index at {level_name}: {idx} (n={n})")
+            continue
+        if idx in seen:
+            continue
+        seen.add(idx)
+        name = str(candidates.iloc[idx - 1][key_col])
+        mode = str(m.get("mode_of_operation", "")).strip().lower()
+        # Empty / unrecognized modes are normalized to "" so downstream
+        # rules (e.g. the indirect-fanout stop) can compare safely.
+        if mode and mode not in {"direct", "enabling tech", "indirect"}:
+            print(f"  [warn] unexpected mode_of_operation at {level_name}: {mode!r}")
+            mode = ""
+        # Confidence: parse to float in [0,1] when present, else None (so a
+        # non-confidence prompt leaves the field blank rather than implying
+        # a score). A missing/unparseable confidence never filters — only an
+        # explicit below-threshold value drops the match.
+        raw_conf = m.get("confidence")
+        if raw_conf is None:
+            confidence = None
+        else:
+            try:
+                confidence = max(0.0, min(1.0, float(raw_conf)))
+            except (TypeError, ValueError):
+                confidence = None
+        if (confidence_threshold is not None and confidence is not None
+                and confidence < confidence_threshold):
+            continue
+        cleaned.append({
+            "name": name,
+            "mode_of_operation": mode,
+            "evidence": str(m.get("evidence", "")).strip(),
+            "reason": str(m.get("reason", "")).strip(),
+            "confidence": confidence,
+        })
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical walk
+# ---------------------------------------------------------------------------
+
+def classify_entity(
+    client: OpenAI,
+    tables: dict[int, pd.DataFrame],
+    levels: list[dict],
+    system_prompt: str,
+    entity_name: str,
+    entity_description: str,
+    model: str,
+    descent_fanout_cap: int,
+    confidence_threshold: float | None = None,
+    emit_per_level: bool = False,
+    seed_names: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Walk the taxonomy top-down for a single entity.
+
+    ``seed_names`` fixes a contiguous top prefix of the levels (mapping each
+    seeded level's ``output_col`` to its value, e.g. ``{"Pillar": "Energy
+    Transition"}``) and the walk descends only the remaining levels from
+    that seeded parent — used to continue into a subtree after a top-level
+    node has been assigned elsewhere (e.g. by the empties recovery). The
+    seeded levels carry no evidence/reason of their own.
+
+    Returns one record per LEAF in the match tree — i.e. per root-to-tip
+    path through the accepted matches. A leaf is a match that was either
+    (a) at the deepest level, (b) had no children matched, (c) truncated
+    by the descent fan-out cap, or (d) tagged ``indirect`` by the prompt
+    when there were multiple sibling matches at the same step (the
+    "indirect-fanout stop"; a no-op when the prompt does not return a
+    ``mode_of_operation`` field).
+
+    Each record has one column per level (named by ``output_col``, empty
+    where the branch stopped early) plus the leaf's level name in
+    ``deepest_match``, plus its definition, mode, evidence, and reason.
+    """
+    empty_leaf = {
+        "deepest_match": None,
+        "leaf_definition": None,
+        "mode_of_operation": None,
+        "evidence": None,
+        "reason": None,
+        "confidence": None,
+    }
+    last_idx = levels[-1]["idx"]
+
+    # path_meta: out_col -> {evidence, reason, confidence, mode} for every
+    # level matched along this path, for the per-level output (emit_per_level).
+    if seed_names:
+        # Reconstruct the seeded prefix's names + parent_path so the walk can
+        # descend its children. Stops seeding at the first level whose value
+        # is missing or not found (then walks normally from there).
+        names: dict[str, Any] = {}
+        parent_path: dict[str, Any] = {}
+        seed_leaf = empty_leaf
+        start_idx = 0
+        for lvl in levels:
+            oc = lvl["output_col"]
+            if oc not in seed_names:
+                break
+            cands = candidates_for_level(tables, lvl["idx"], parent_path)
+            match = cands[cands[lvl["key_col"]] == seed_names[oc]]
+            if match.empty:
+                break
+            row = match.iloc[0]
+            names[oc] = seed_names[oc]
+            if lvl["idx"] != last_idx:
+                parent_path[lvl["child_filter_col"]] = row[lvl["child_filter_value_col"]]
+            seed_leaf = {
+                "deepest_match": lvl["name"],
+                "leaf_definition": str(row["Definition"]).strip(),
+                "mode_of_operation": None,
+                "evidence": None,
+                "reason": None,
+                "confidence": None,
+            }
+            start_idx = lvl["idx"] + 1
+        initial_branch = {"names": names, "parent_path": parent_path,
+                          "leaf": seed_leaf, "path_meta": {}}
+        levels_to_walk = [lvl for lvl in levels if lvl["idx"] >= start_idx]
+    else:
+        initial_branch = {
+            "names": {}, "parent_path": {}, "leaf": empty_leaf, "path_meta": {},
+        }
+        levels_to_walk = levels
+
+    active: list[dict[str, Any]] = [initial_branch]
+    leaves: list[dict[str, Any]] = []
+
+    for lvl in levels_to_walk:
+        level_idx = lvl["idx"]
+        key_col = lvl["key_col"]
+        out_col = lvl["output_col"]
+        is_last_level = level_idx == last_idx
+        if not is_last_level:
+            child_filter_col = lvl["child_filter_col"]
+            child_filter_value_col = lvl["child_filter_value_col"]
+
+        next_active: list[dict[str, Any]] = []
+
+        for branch in active:
+            candidates = candidates_for_level(tables, level_idx, branch["parent_path"])
+            if candidates.empty:
+                if branch["leaf"] is not empty_leaf:
+                    leaves.append(branch)
+                continue
+
+            matches = call_openai_match(
+                client=client,
+                system_prompt=system_prompt,
+                model=model,
+                entity_name=entity_name,
+                entity_description=entity_description,
+                level_name=lvl["name"],
+                candidates=candidates,
+                key_col=key_col,
+                confidence_threshold=confidence_threshold,
+            )
+
+            if not matches:
+                if branch["leaf"] is not empty_leaf:
+                    leaves.append(branch)
+                continue
+
+            for i, m in enumerate(matches):
+                cand_row = candidates[candidates[key_col] == m["name"]].iloc[0]
+                new_names = dict(branch["names"])
+                new_names[out_col] = m["name"]
+                new_parent_path = dict(branch["parent_path"])
+                if not is_last_level:
+                    new_parent_path[child_filter_col] = cand_row[child_filter_value_col]
+                new_leaf = {
+                    "deepest_match": lvl["name"],
+                    "leaf_definition": str(cand_row["Definition"]).strip(),
+                    "mode_of_operation": m["mode_of_operation"],
+                    "evidence": m["evidence"],
+                    "reason": m["reason"],
+                    "confidence": m.get("confidence"),
+                }
+                new_path_meta = dict(branch["path_meta"])
+                new_path_meta[out_col] = {
+                    "evidence": m["evidence"],
+                    "reason": m["reason"],
+                    "confidence": m.get("confidence"),
+                    "mode_of_operation": m["mode_of_operation"],
+                }
+                new_branch = {
+                    "names": new_names,
+                    "parent_path": new_parent_path,
+                    "leaf": new_leaf,
+                    "path_meta": new_path_meta,
+                }
+                # Indirect-fanout stop: an `indirect` (advocacy / policy /
+                # education) match descends only when it is the SOLE match
+                # at this step. Multiple indirect siblings indicate the
+                # entity advocates broadly across the level and naming any
+                # specific child would be guesswork; record them as final
+                # leaves at the current level instead. Direct / enabling-
+                # tech matches still descend normally (subject to the
+                # fan-out cap).
+                indirect_fanout = (
+                    m["mode_of_operation"] == "indirect"
+                    and len(matches) > 1
+                )
+                if is_last_level or i >= descent_fanout_cap or indirect_fanout:
+                    leaves.append(new_branch)
+                else:
+                    next_active.append(new_branch)
+
+        active = next_active
+        if not active:
+            break
+
+    leaves.extend(active)
+
+    out_cols = [lvl["output_col"] for lvl in levels]
+
+    def _record(b: dict[str, Any]) -> dict[str, Any]:
+        rec = {c: b["names"].get(c) for c in out_cols}
+        rec.update(b["leaf"])
+        if emit_per_level:
+            # Per-level evidence / reason / confidence for every level matched
+            # on this path (None where the branch stopped short). Columns are
+            # named "<output_col> evidence" etc.
+            for oc in out_cols:
+                pm = b["path_meta"].get(oc, {})
+                rec[f"{oc} evidence"] = pm.get("evidence")
+                rec[f"{oc} reason"] = pm.get("reason")
+                rec[f"{oc} confidence"] = pm.get("confidence")
+        return rec
+
+    return [_record(b) for b in leaves]
+
+
+# ---------------------------------------------------------------------------
+# Per-entity worker
+# ---------------------------------------------------------------------------
+
+def _classify_one(
+    client: OpenAI,
+    tables: dict[int, pd.DataFrame],
+    levels: list[dict],
+    system_prompt: str,
+    row: pd.Series,
+    id_col: str,
+    name_col: str,
+    text_col: str,
+    model: str,
+    descent_fanout_cap: int,
+    confidence_threshold: float | None = None,
+    emit_per_level: bool = False,
+    seed_col: str | None = None,
+) -> list[dict[str, Any]]:
+    """Classify a single entity and return flat output rows.
+
+    All columns of ``row`` are carried through into ``base`` so the
+    per-row output keeps any extra attributes (Funding, x/y, etc.).
+    Emits one null-taxonomy row when there is no level-0 match so the
+    entity still appears in the output. When ``seed_col`` is set and the
+    row has a non-empty value there, the walk is seeded at the top level
+    with that value (see ``classify_entity``'s ``seed_names``).
+    """
+    name = str(row[name_col])
+    desc = str(row[text_col])
+    base = {col: row[col] for col in row.index}
+    base[name_col] = name
+    base[text_col] = desc
+
+    seed_names = None
+    if seed_col is not None:
+        seed_val = row.get(seed_col)
+        if seed_val is not None and str(seed_val).strip() not in ("", "nan", "None"):
+            seed_names = {levels[0]["output_col"]: str(seed_val)}
+
+    try:
+        records = classify_entity(
+            client=client,
+            tables=tables,
+            levels=levels,
+            system_prompt=system_prompt,
+            entity_name=name,
+            entity_description=desc,
+            model=model,
+            descent_fanout_cap=descent_fanout_cap,
+            confidence_threshold=confidence_threshold,
+            emit_per_level=emit_per_level,
+            seed_names=seed_names,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [error] {name}: {exc}")
+        return []
+
+    leaf_keys = ["deepest_match", "leaf_definition",
+                 "mode_of_operation", "evidence", "reason", "confidence"]
+    if not records:
+        empty = {lvl["output_col"]: None for lvl in levels}
+        empty.update({k: None for k in leaf_keys})
+        if emit_per_level:
+            for lvl in levels:
+                oc = lvl["output_col"]
+                empty[f"{oc} evidence"] = None
+                empty[f"{oc} reason"] = None
+                empty[f"{oc} confidence"] = None
+        return [{**base, **empty}]
+    return [{**base, **r} for r in records]
+
+
+# ---------------------------------------------------------------------------
+# Batch entry point
+# ---------------------------------------------------------------------------
+
+def classify_entities(
+    *,
+    client: OpenAI,
+    tables: dict[int, pd.DataFrame],
+    levels: list[dict],
+    system_prompt: str,
+    entities: pd.DataFrame,
+    id_col: str,
+    name_col: str,
+    text_col: str,
+    model: str = "gpt-4.1",
+    descent_fanout_cap: int = 3,
+    max_workers: int = 8,
+    confidence_threshold: float | None = None,
+    emit_per_level: bool = False,
+    seed_col: str | None = None,
+) -> pd.DataFrame:
+    """Classify many entities in parallel; return one flat DataFrame.
+
+    When ``seed_col`` is set, each entity whose ``seed_col`` value is
+    non-empty has its walk seeded at the top level with that value (the
+    walk descends that node's subtree); entities with an empty seed walk
+    from the root as usual. Useful for descending into a subtree after a
+    top-level assignment from elsewhere (e.g. the empties recovery).
+
+    ``entities`` must have at least ``id_col``, ``name_col``, ``text_col``.
+    The output has those columns followed by every other entity column
+    (in input order), then one column per level (``output_col``), then
+    five leaf columns: ``deepest_match``, ``leaf_definition``,
+    ``mode_of_operation``, ``evidence``, ``reason``.
+
+    Uses a thread pool because each entity's hierarchical walk is
+    independent and the work is I/O-bound on the OpenAI API.
+    """
+    levels = normalize_levels(levels)
+
+    print(
+        f"Classifying {len(entities)} entities "
+        f"with {max_workers} worker(s)"
+    )
+
+    all_records: list[dict[str, Any]] = []
+    t0 = time.time()
+
+    if max_workers <= 1:
+        # Single-threaded path — kept unthreaded to make debugging easier.
+        for i, row in entities.iterrows():
+            print(f"[{i + 1}/{len(entities)}] {row[name_col]}")
+            all_records.extend(_classify_one(
+                client, tables, levels, system_prompt, row,
+                id_col, name_col, text_col, model, descent_fanout_cap,
+                confidence_threshold, emit_per_level, seed_col,
+            ))
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(
+                    _classify_one,
+                    client, tables, levels, system_prompt, row,
+                    id_col, name_col, text_col, model, descent_fanout_cap,
+                    confidence_threshold, emit_per_level, seed_col,
+                ): row
+                for _, row in entities.iterrows()
+            }
+            done = 0
+            for fut in as_completed(futures):
+                row = futures[fut]
+                done += 1
+                recs = fut.result()
+                print(f"[{done}/{len(entities)}] {row[name_col]} -> {len(recs)} rows")
+                all_records.extend(recs)
+
+    print(f"\nTotal elapsed: {time.time() - t0:.1f}s")
+
+    front = [id_col, name_col, text_col]
+    extras = [c for c in entities.columns if c not in front]
+    classification_cols = (
+        [lvl["output_col"] for lvl in levels]
+        + ["deepest_match", "leaf_definition",
+           "mode_of_operation", "evidence", "reason", "confidence"]
+    )
+    if emit_per_level:
+        for lvl in levels:
+            oc = lvl["output_col"]
+            classification_cols += [f"{oc} evidence", f"{oc} reason",
+                                    f"{oc} confidence"]
+    out_cols = front + extras + classification_cols
+    return pd.DataFrame(all_records, columns=out_cols)
+
+
+# ---------------------------------------------------------------------------
+# Collapsed (one-row-per-id) output
+# ---------------------------------------------------------------------------
+
+def _dedup_preserve(values: list) -> list:
+    """Keep the first occurrence of each non-null/non-empty value."""
+    seen: set = set()
+    out: list = []
+    for v in values:
+        if v is None:
+            continue
+        if isinstance(v, float) and pd.isna(v):
+            continue
+        s = str(v).strip()
+        if not s:
+            continue
+        if s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def collapse_to_one_row_per_uid(
+    df: pd.DataFrame,
+    levels: list[dict],
+    id_col: str = "uid",
+) -> pd.DataFrame:
+    """Collapse a per-row classification DataFrame to one row per id_col.
+
+    Each level's per-row column (``output_col``) becomes a list of the
+    unique non-empty values seen for that id, rendered with ``repr()`` so
+    cells round-trip via ``ast.literal_eval``. The collapsed column uses
+    the level's ``name`` as its header (so e.g. Drawdown's per-row
+    ``Cluster`` column becomes the collapsed ``SectorCluster`` column).
+    The deepest non-empty level's ``name`` is reported in
+    ``deepest_match``; ids with all level lists empty get
+    ``deepest_match == "NoMatch"``.
+
+    Non-classification columns (anything that isn't ``id_col`` or one of
+    the level / leaf columns) carry through using each id's first
+    non-null value.
+    """
+    levels = normalize_levels(levels)
+
+    classification_set = (
+        {lvl["output_col"] for lvl in levels}
+        | {"deepest_match", "leaf_definition",
+           "mode_of_operation", "evidence", "reason"}
+    )
+    carry_cols = [c for c in df.columns if c != id_col and c not in classification_set]
+
+    rows: list[dict[str, Any]] = []
+    for uid, group in df.groupby(id_col, sort=False):
+        row: dict[str, Any] = {id_col: uid}
+        for col in carry_cols:
+            non_null = group[col].dropna()
+            row[col] = non_null.iloc[0] if len(non_null) else None
+
+        deepest_name: str | None = None
+        for lvl in levels:
+            src = lvl["output_col"]
+            collapsed_col = lvl["name"]
+            values = _dedup_preserve(group[src].tolist()) if src in group else []
+            row[collapsed_col] = repr(values)
+            if values:
+                deepest_name = lvl["name"]
+        row["deepest_match"] = deepest_name if deepest_name else "NoMatch"
+
+        modes = (
+            _dedup_preserve(group["mode_of_operation"].tolist())
+            if "mode_of_operation" in group else []
+        )
+        row["mode_of_operation"] = repr(modes)
+        rows.append(row)
+
+    out_cols = (
+        [id_col]
+        + carry_cols
+        + [lvl["name"] for lvl in levels]
+        + ["deepest_match", "mode_of_operation"]
+    )
+    return pd.DataFrame(rows, columns=out_cols)
+
+
+# ---------------------------------------------------------------------------
+# Recovery of unmatched entities (second-stage scope check)
+# ---------------------------------------------------------------------------
+
+def build_default_scope_prompt(
+    tables: dict[int, pd.DataFrame],
+    levels: list[dict],
+) -> str:
+    """Generic default scope prompt for ``recover_unmatched``.
+
+    Renders the top-level node names + definitions from the taxonomy and a
+    generic in-scope/category/reason instruction. This is the runnable
+    baseline — like the engine's default rule bodies, it works for any
+    taxonomy with no authoring, but a caller-supplied ``scope_prompt`` with
+    domain-specific in/out guidance and routing will classify more
+    accurately.
+    """
+    levels = normalize_levels(levels)
+    top = levels[0]
+    t = tables[top["idx"]]
+    block = "\n".join(
+        f"- {row[top['key_col']]}: {str(row['Definition']).strip()}"
+        for _, row in t.iterrows()
+        if pd.notna(row.get(top["key_col"])) and pd.notna(row.get("Definition"))
+    )
+    return (
+        "You decide whether an entity's own work is in scope for the taxonomy "
+        "below. Top-level categories and their scope:\n"
+        f"{block}\n\n"
+        "Judge by whether the entity's own activity is itself one of these "
+        "categories (an implicit mechanism is acceptable), not an incidental "
+        "side-effect of otherwise out-of-scope work. Return JSON: "
+        "{\"in_scope\": true|false, \"category\": \"<exact category name or "
+        "null>\", \"reason\": \"<one sentence>\"}."
+    )
+
+
+def recover_unmatched(
+    df: pd.DataFrame,
+    *,
+    client: OpenAI,
+    model: str,
+    id_col: str,
+    name_col: str,
+    text_col: str,
+    levels: list[dict] | None = None,
+    tables: dict[int, pd.DataFrame] | None = None,
+    top_level_col: str | None = None,
+    category_choices: Iterable[str] | None = None,
+    scope_prompt: str | None = None,
+    max_workers: int = 8,
+) -> pd.DataFrame:
+    """Second-stage scope check on entities the walk left unmatched.
+
+    The top-down walk is precision-tuned and refuses entities whose
+    in-scope activity is described obliquely (civic / service framing) —
+    but those refusals are a mix of genuine out-of-scope and missed
+    in-scope. The walk's own (single, refusing) judgment cannot tell them
+    apart. This runs an INDEPENDENT scope judgment with ``model`` (use a
+    stronger model than the classifier) over only the entities with no
+    top-level match, returning whether each is in scope and which
+    top-level category fits.
+
+    Adds three columns, filled only for unmatched entities (matched
+    entities and their rows keep ``None``):
+        - ``recovered_in_scope``      bool | None
+        - ``recovered_<top_level_col>`` str | None  (validated category)
+        - ``recovered_reason``        str | None
+
+    ``top_level_col``, ``category_choices``, and ``scope_prompt`` each
+    default from ``levels`` + ``tables`` when omitted (top-level output
+    column; top-level node names; ``build_default_scope_prompt``), so a
+    generic caller can pass just ``levels`` + ``tables``. Supply any of them
+    explicitly to override — a domain-specific ``scope_prompt`` in
+    particular classifies more accurately than the default. The scope prompt
+    must instruct the model to return JSON ``{"in_scope": bool, "<category
+    key>": "<name or null>", "reason": "..."}``; category values are
+    validated (case-insensitively) against ``category_choices``.
+    """
+    if top_level_col is None or category_choices is None or scope_prompt is None:
+        if levels is None or tables is None:
+            raise ValueError(
+                "recover_unmatched: supply levels + tables to default "
+                "top_level_col / category_choices / scope_prompt, or pass all "
+                "three explicitly."
+            )
+        nlevels = normalize_levels(levels)
+        top = nlevels[0]
+        if top_level_col is None:
+            top_level_col = top["output_col"]
+        if category_choices is None:
+            category_choices = list(tables[top["idx"]][top["key_col"]].dropna())
+        if scope_prompt is None:
+            scope_prompt = build_default_scope_prompt(tables, nlevels)
+
+    cats = {str(c).strip().lower(): str(c) for c in category_choices}
+
+    def _empty(s: pd.Series) -> pd.Series:
+        return s.isna() | s.astype(str).str.strip().isin(["", "None", "nan"])
+
+    unmatched_ids = [
+        uid for uid, g in df.groupby(id_col, sort=False)
+        if bool(_empty(g[top_level_col]).all())
+    ]
+    rep = (df[df[id_col].isin(unmatched_ids)]
+           .drop_duplicates(id_col).set_index(id_col))
+
+    cat_key = top_level_col.strip().lower()
+
+    def _recover(uid: Any) -> tuple[Any, tuple]:
+        name = str(rep.loc[uid, name_col])
+        text = str(rep.loc[uid, text_col])
+        user_prompt = f"Organization: {name}\n\nDescription:\n{text}"
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "system", "content": scope_prompt},
+                          {"role": "user", "content": user_prompt}],
+                response_format={"type": "json_object"}, temperature=0,
+            )
+            data = json.loads(resp.choices[0].message.content or "{}")
+            in_scope = bool(data.get("in_scope"))
+            raw_cat = data.get(cat_key) or data.get("category") or data.get("pillar")
+            cat = cats.get(str(raw_cat).strip().lower()) if raw_cat else None
+            reason = str(data.get("reason", "")).strip()
+            return uid, (in_scope, cat if in_scope else None, reason)
+        except Exception as exc:  # noqa: BLE001
+            return uid, (None, None, f"recovery error: {exc}")
+
+    results: dict[Any, tuple] = {}
+    if unmatched_ids:
+        print(f"Recovering {len(unmatched_ids)} unmatched entities with {model}")
+        if max_workers <= 1:
+            for uid in unmatched_ids:
+                _, res = _recover(uid)
+                results[uid] = res
+        else:
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                for uid, res in pool.map(_recover, unmatched_ids):
+                    results[uid] = res
+
+    df = df.copy()
+    none3 = (None, None, None)
+    df["recovered_in_scope"] = df[id_col].map(lambda u: results.get(u, none3)[0])
+    df[f"recovered_{top_level_col}"] = df[id_col].map(lambda u: results.get(u, none3)[1])
+    df["recovered_reason"] = df[id_col].map(lambda u: results.get(u, none3)[2])
+    return df

--- a/vdl_tools/shared_tools/taxonomy_mapping/uncached_oe_hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/uncached_oe_hierarchical_taxonomy_mapping.py
@@ -1,0 +1,1048 @@
+"""
+One Earth hierarchical taxonomy mapping — library
+==================================================
+
+Reusable classifier that maps any DataFrame of entities (companies,
+organizations, projects — anything with a name and a description) onto
+the four-level One Earth Climate Solutions Framework taxonomy:
+
+    0. Pillar      (5 nodes: Energy Transition, Nature Conservation,
+                    Regenerative Agriculture, Cross-Cutting, Geo-Engineering)
+    1. Sub-Pillar  (~17 nodes; children of a Pillar)
+    2. Solution    (~120 nodes; children of a Sub-Pillar)
+    3. Sub-Term    (~700+ nodes; children of a Solution; absent for the
+                    Cross-Cutting pillar — walk leafs at Solution there)
+
+This is the data + prompt half. The CFT-specific driver (loading the
+CFT JSON, sampling, writing the xlsx triplet, comparing to the prior
+``One Earth *`` columns) lives in ``run_oe_hierarchical_mapping.py``.
+
+Eventual home: ``vdl_tools/shared_tools/taxonomy_mapping/``. Once moved
+there, ``SHARED_TAXONOMY_DIR`` should be relativized via
+``vdl_tools.shared_tools.project_config`` rather than the absolute path
+used here for now.
+
+High-level usage
+----------------
+    from openai import OpenAI
+    from oe_hierarchical_taxonomy_mapping import map_to_oneearth
+
+    client = OpenAI(api_key=...)
+    per_row_df, collapsed_df = map_to_oneearth(
+        entities=my_dataframe,
+        id_col="uid",
+        name_col="Name",
+        text_col="Description",
+        client=client,
+    )
+
+The library re-exports ``build_system_prompt``, ``classify_entities``,
+``classify_entity`` from the generic engine for callers that want to
+drive the walk themselves with custom level specs / prompts.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pandas as pd
+from openai import OpenAI
+
+# Repointed to the sibling ``uncached_`` engine so this frozen pre-refactor
+# ("uncached") OE module pairs with the pre-refactor engine, independent of
+# the refactored ``hierarchical_taxonomy_mapping`` on this branch.
+import vdl_tools.shared_tools.taxonomy_mapping.uncached_hierarchical_taxonomy_mapping as _htm
+from vdl_tools.shared_tools.taxonomy_mapping.uncached_hierarchical_taxonomy_mapping import (
+    build_system_prompt,
+    classify_entities,
+    classify_entity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# TODO: relativize SHARED_TAXONOMY_DIR via vdl_tools.shared_tools.project_config
+# when this file moves to vdl_tools/shared_tools/taxonomy_mapping/.
+SHARED_TAXONOMY_DIR = Path(
+    "/Users/rjw/Dropbox/VDL/shared-data-clean/data/taxonomies/oneearth"
+)
+
+MODEL = "gpt-5.4-nano"
+DESCENT_FANOUT_CAP = 3
+DEFAULT_WORKERS = 32  # I/O-bound on the OpenAI API; large pools are fine.
+
+# Per-pillar sheets that carry Sub-Term-level rows. The Cross-Cutting
+# pillar has no per-pillar sheet, so its Solutions naturally have no
+# Sub-Terms — the walk leafs at Solution there.
+PILLAR_DETAIL_SHEETS = (
+    "Energy",
+    "Regenerative Ag",
+    "Nature Conservation",
+    "Geo-Engineering",
+)
+
+
+# ---------------------------------------------------------------------------
+# Latest-version discovery
+# ---------------------------------------------------------------------------
+
+def find_latest_taxonomy(
+    taxonomy_dir: Path = SHARED_TAXONOMY_DIR,
+) -> Path:
+    """Return the latest VDL-edited OE Solutions Terms xlsx in ``taxonomy_dir``.
+
+    Picks files matching ``OE Solutions Terms *VDL.xlsx`` and chooses the
+    one with the largest 8-digit YYYYMMDD prefix in the trailing token.
+    Files with no date (e.g. ``OE Solutions Terms VDL.xlsx``) sort
+    earliest so any dated file beats them.
+    """
+    candidates = list(taxonomy_dir.glob("OE Solutions Terms *VDL.xlsx"))
+    if not candidates:
+        raise FileNotFoundError(
+            f"No OE Solutions Terms *VDL.xlsx file found in {taxonomy_dir}"
+        )
+
+    def date_key(p: Path) -> str:
+        # The dated names look like 'OE Solutions Terms 20250502_expanded_VDL.xlsx';
+        # the bare 'OE Solutions Terms VDL.xlsx' has no date and should sort
+        # earliest. Pull the leftmost 8-digit run from the stem.
+        m = re.search(r"\d{8}", p.stem)
+        return m.group(0) if m else "00000000"
+
+    return max(candidates, key=date_key)
+
+
+# ---------------------------------------------------------------------------
+# One Earth level spec
+# ---------------------------------------------------------------------------
+# A 4-level walk: Pillar -> Sub-Pillar -> Solution -> Sub-Term.
+#
+# The default child filters work because each level's parent-side column
+# in the source data uses the same name as the parent's key_col:
+#   Sub-Pillar rows carry "Pillar"
+#   Solution rows carry "Pillar" + "Sub-Pillar"
+#   Sub-Term rows (synthesized below) carry "Pillar" + "Sub-Pillar" + "Solution"
+# So no child_filter_col / child_filter_value_col overrides are needed.
+#
+# The level-3 sheet name is a placeholder; ``load_taxonomy`` below
+# builds the Sub-Term frame in memory rather than reading a single sheet.
+
+ONEEARTH_LEVELS = [
+    {
+        "idx": 0, "name": "Pillar",
+        "sheet": "Pillars", "key_col": "Pillar",
+        "output_col": "Pillar",
+        "parent_filters": [],
+    },
+    {
+        "idx": 1, "name": "SubPillar",
+        "sheet": "SubPillars", "key_col": "Sub-Pillar",
+        "output_col": "Sub-Pillar",
+        "parent_filters": ["Pillar"],
+    },
+    {
+        "idx": 2, "name": "Solution",
+        "sheet": "Solutions", "key_col": "Solution",
+        "output_col": "Solution",
+        "parent_filters": ["Pillar", "Sub-Pillar"],
+    },
+    {
+        "idx": 3, "name": "SubTerm",
+        "sheet": "_SubTerms_synthetic", "key_col": "Sub-Term",
+        "output_col": "Sub-Term",
+        "parent_filters": ["Pillar", "Sub-Pillar", "Solution"],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# One Earth system prompt — assembled from generic skeleton + OE overrides
+# ---------------------------------------------------------------------------
+# Same three-layer customization the Drawdown driver uses: domain intro,
+# modes-of-operation (copied verbatim — definitions are domain-agnostic),
+# and rule overrides. ``evidence_only`` and ``multiple_matches`` use the
+# engine's defaults.
+
+ONEEARTH_DOMAIN_INTRO = (
+    "You are classifying an organization against the One Earth Climate "
+    "Solutions Framework, a hierarchical taxonomy of climate-action "
+    "solutions for keeping global warming below 1.5°C. The taxonomy has "
+    "four levels — Pillar, Sub-Pillar, Solution, Sub-Term — nested under "
+    "five top-level pillars:\n"
+    "- Energy Transition: clean renewable power, heat, transport, "
+    "electrification, energy storage, EV infrastructure, building energy "
+    "systems, and industrial decarbonization.\n"
+    "- Nature Conservation: protecting, restoring, and connecting "
+    "forests, grasslands, wetlands, peatlands, and oceans.\n"
+    "- Regenerative Agriculture: soil-restoring farming, reduced "
+    "chemical inputs, and food-system transformation, including food "
+    "waste reduction.\n"
+    "- Geo-Engineering: intentional large-scale interventions in Earth "
+    "systems such as carbon dioxide removal or solar radiation "
+    "management.\n"
+    "- Cross-Cutting: field-building and enabling work (tools, data, "
+    "monitoring, policy, finance, legal, education, advocacy) that "
+    "spans two or more of the other four pillars. It is a leaf with no "
+    "sub-pillars or solutions of its own, not a fallback bucket.\n"
+    "Return an empty match list when the organization's work falls "
+    "outside all five pillars — e.g. general social services, "
+    "non-climate health, sports, consumer products with no climate "
+    "angle, or generic economic development."
+)
+
+# Copied verbatim from the Drawdown driver — the definitions are
+# domain-agnostic and transfer cleanly.
+ONEEARTH_MODES = [
+    {
+        "name": "direct",
+        "definition": (
+            "the entity itself deploys, operates, produces, implements, "
+            "or performs the solution activity (e.g. builds solar farms, "
+            "runs regenerative agriculture, manufactures low-carbon "
+            "cement, restores wetlands)."
+        ),
+    },
+    {
+        "name": "enabling tech",
+        "definition": (
+            "the entity develops or supplies technology, hardware, "
+            "software, tools, materials, financing, or services that "
+            "make the solution possible for others to deploy, but does "
+            "not deploy it itself at scale (e.g. sells sensors to wind "
+            "farms, builds software for grid operators, provides capital "
+            "to project developers)."
+        ),
+    },
+    {
+        "name": "indirect",
+        "definition": (
+            "the entity works on public policy, advocacy, awareness, "
+            "education, standards, research without deployment, "
+            "convening, or other non-deployment levers of change that "
+            "shape whether or how the solution is adopted."
+        ),
+    },
+]
+
+ONEEARTH_RULE_OVERRIDES = {
+    "domain_relevance": (
+        "Climate-action relevance. Match a candidate when the description "
+        "names activities aligned with the candidate's definition. The "
+        "taxonomy already establishes the climate mechanism for each "
+        "candidate — decide whether the description names the activity, "
+        "not whether the activity helps the climate. An organization's "
+        "products, services, or stated mission are sufficient evidence at "
+        "the Pillar / Sub-Pillar level even when the climate mechanism is "
+        "left implicit.\n"
+        "The activity classes below are IN SCOPE and map as shown. These "
+        "inclusions grant entry at the Pillar / Sub-Pillar level only; "
+        "selecting a specific Solution or Sub-Term still requires the "
+        "description to name that specific activity (see the specificity "
+        "rule):\n"
+        "- Low-carbon or circular materials, recycling, and material "
+        "substitution (bioplastics, recycled or bio-based fibers, "
+        "low-carbon cement / chemicals, battery or e-waste recycling) -> "
+        "Energy Transition (industrial decarbonization).\n"
+        "- Food-system work: regenerative, urban, or indoor / controlled-"
+        "environment farming, agroecology, local / organic food systems, "
+        "alternative proteins, food-waste reduction / rescue / upcycling, "
+        "composting, and sustainable fibers or textile recycling "
+        "(fibersheds) -> Regenerative Agriculture.\n"
+        "- Ecosystem protection, restoration, or connection (forests, "
+        "grasslands, wetlands, peatlands, oceans, coastal habitats, urban "
+        "green infrastructure) and conservation-enabling work "
+        "(biodiversity data, conservation finance, monitoring, policy, "
+        "education) -> Nature Conservation.\n"
+        "- Carbon dioxide removal or capture (direct air capture, "
+        "mineralization or carbon-storing materials, enhanced weathering, "
+        "ocean or biogenic CDR) and carbon-credit / MRV infrastructure "
+        "for capture -> Geo-Engineering.\n"
+        "- Climate field-building that enables others (data platforms, "
+        "monitoring, finance, policy, legal, education, advocacy, "
+        "incubators) -> placed by scope; see the cross-pillar rule.\n"
+        "Out of scope: fossil-fuel extraction, processing, or transport; "
+        "conventional chemical-input agribusiness; consumer goods carrying "
+        "only a 'sustainable' / 'green' label with no climate mechanism; "
+        "general social services, recreation, emergency services, "
+        "non-environmental health or education, and generic economic "
+        "development. When the description is too thin to commit even to a "
+        "Pillar, return `matches: []`.\n"
+        "At the Pillar level, bias plausible but uncertain matches toward "
+        "inclusion. The specificity and qualifier cautions in the other "
+        "rules govern the choice of a Solution or Sub-Term — they do not "
+        "justify withholding a Pillar because the description names no "
+        "specific technology, practice, or qualifier."
+    ),
+    "cross_sector": (
+        "No cross-pillar inference. Assign a pillar only for an activity the "
+        "entity itself performs, supplies, or advances. An entity that "
+        "supplies a low-carbon input or service to another pillar stays in "
+        "its own pillar unless the description says it also operates in that "
+        "pillar."
+    ),
+    "prominence": (
+        "Prominence. Match a Pillar or Sub-Pillar for any activity that is "
+        "the entity's own work — its products, services, or stated mission "
+        "— even if described in a single phrase or sentence; do not require "
+        "multiple sentences or \"primary focus\" framing at these levels. "
+        "What fails this bar is an activity that is not the entity's own "
+        "(e.g. \"our clients include solar firms\") or a throwaway mention "
+        "of something otherwise absent from the description. At the Solution "
+        "/ Sub-Term levels, a specifically named technology or practice is "
+        "likewise sufficient even if briefly mentioned."
+    ),
+}
+
+# Cross-pillar routing — disambiguation for activities that could plausibly
+# fit more than one pillar. Definitions hold scope; the prompt holds routing.
+# Appended as its own labeled section (build_system_prompt only emits the
+# fixed PROMPT_RULE_KEYS). Mirrored 1:1 in the judge's scope intro.
+ONEEARTH_CROSS_PILLAR_ROUTING = (
+    "Cross-pillar routing. When work could plausibly fit more than one "
+    "pillar, route it as follows:\n"
+    "- Field-builders / ecosystem-builders whose own work is enabling tools "
+    "(data, monitoring, finance, science) or enabling conditions (policy, "
+    "legal, education, advocacy, incubation): bounded to ONE primary pillar "
+    "-> that pillar's `Cross-Cutting <Pillar>` sub-pillar; spanning TWO OR "
+    "MORE primary pillars -> the top-level Cross-Cutting pillar. Cross-Cutting "
+    "is never a fallback for a poor fit — an entity that builds, deploys, or "
+    "supplies a SPECIFIC solution belongs to that solution's pillar.\n"
+    "- Carbon capture, transport, storage, or removal — including "
+    "point-source capture at fossil or industrial facilities — is "
+    "Geo-Engineering / Engineered CDR, not Energy Transition, whenever that "
+    "is the primary climate mechanism.\n"
+    "- Classify by product or activity, not feedstock: bio-based, "
+    "biodegradable, or recycled plastics and organic / green chemicals are "
+    "Energy Transition (Organic Chemicals & Plastics) even when made from "
+    "agricultural or organic-waste feedstock; fibers, textiles, and clothing "
+    "are Regenerative Agriculture (circular fibersheds); food and farming "
+    "products are Regenerative Agriculture; materials whose primary purpose "
+    "is capturing or sequestering CO2 are Geo-Engineering."
+)
+
+
+def build_oneearth_system_prompt(include_confidence: bool = False) -> str:
+    """Assemble the canonical One Earth organization system prompt.
+
+    Generic skeleton + OE rule overrides (domain_relevance with a
+    Pillar-level inclusion bias, generic cross_sector, prominence) + the
+    standalone cross-pillar routing section. ``include_confidence=True``
+    adds the per-match confidence schema/instruction for the
+    confidence-threshold knob.
+    """
+    prompt = build_system_prompt(
+        levels=ONEEARTH_LEVELS,
+        domain_intro=ONEEARTH_DOMAIN_INTRO,
+        modes=ONEEARTH_MODES,
+        rules=ONEEARTH_RULE_OVERRIDES,
+        include_confidence=include_confidence,
+    )
+    return prompt + "\n\n" + ONEEARTH_CROSS_PILLAR_ROUTING
+
+
+ONEEARTH_SYSTEM_PROMPT = build_oneearth_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# Research-project prompt variant
+# ---------------------------------------------------------------------------
+# The default prompt above is calibrated for organizations (companies,
+# NGOs, land trusts) — its modes describe what an "entity" does and its
+# rule overrides are full of organization-shaped examples ("land trust",
+# "Audubon-style organization", "regenerative-farming co-op"). Research-
+# grant abstracts (NSF, NIH, USAspending) describe investigations rather
+# than operations, and the org-tuned framing causes the LLM to miss
+# applied / mechanism research that legitimately maps to deployment-
+# shaped taxonomy nodes.
+#
+# The constants below provide a coordinated alternative — domain intro
+# framed for research projects, modes-of-operation reworded around
+# research roles (while keeping the engine's canonical mode names), and
+# rule overrides with research-shaped examples and exclusions. Callers
+# select the variant via ``map_to_oneearth(prompt_mode="research")``.
+# All three pieces move as a triple; mixing the org domain_intro with
+# research modes (or vice versa) produces incoherent prompts.
+
+ONEEARTH_RESEARCH_DOMAIN_INTRO = (
+    "You are classifying a description of a scientific research project "
+    "(e.g. an NSF, NIH, or USAspending grant abstract) against the One "
+    "Earth Climate Solutions Framework — a hierarchical taxonomy of "
+    "climate-action solutions designed to keep global warming below "
+    "1.5°C. The taxonomy is organized into five pillars: Energy "
+    "Transition (clean renewable power, heat, transport, "
+    "electrification, batteries / energy storage, EV infrastructure, "
+    "building energy systems, and industrial decarbonization), Nature "
+    "Conservation (protecting, restoring, and connecting forests, "
+    "grasslands, wetlands, peatlands, and oceans), Regenerative "
+    "Agriculture (soil-restoring farming, reduced chemical inputs, and "
+    "food-system transformation), Cross-Cutting (research that spans "
+    "multiple primary pillars OR provides field-building tools / "
+    "enabling conditions across the climate field — typically climate "
+    "science, monitoring, modeling, policy, finance, or education), "
+    "and Geo-Engineering (intentional large-scale interventions in "
+    "Earth systems such as carbon dioxide removal or solar radiation "
+    "management).\n\n"
+    "Your task: identify which taxonomy nodes the research project "
+    "investigates, develops, validates, demonstrates, or otherwise "
+    "advances. The project does NOT have to deploy the named solution "
+    "to count as a match — research that develops methodology, "
+    "validates a component, characterizes a material, models a system, "
+    "or investigates the underlying mechanism of a recognized solution "
+    "all match. Match by what the project's research activity "
+    "actually IS, not by speculative downstream applications. Every "
+    "taxonomy node describes a specific climate-action solution; the "
+    "match must be to a named research target, not to general "
+    "sustainability framing in a broader-impacts statement."
+)
+
+# Research-shaped mode definitions, but using the engine's three
+# canonical mode names (direct / enabling tech / indirect) so the
+# engine's hardcoded validation accepts the values without warning and
+# downstream mode-aware logic (e.g. indirect-fanout stop) keeps working.
+ONEEARTH_RESEARCH_MODES = [
+    {
+        "name": "direct",
+        "definition": (
+            "the project itself implements, deploys, restores, "
+            "sequesters, manufactures, or runs a field demonstration "
+            "of the named solution at real-world scale — e.g. installs "
+            "a microgrid, restores wetlands at a specific site, runs a "
+            "methane-leak monitoring deployment, plants cover crops on "
+            "working farms, field-trials a geoengineering intervention. "
+            "This is the rarest mode in research-grant data; most "
+            "research is upstream of deployment."
+        ),
+    },
+    {
+        "name": "enabling tech",
+        "definition": (
+            "the project develops, validates, characterizes, "
+            "prototypes, or investigates the mechanism behind a "
+            "specific named technology, material, process, or practice "
+            "that maps to a taxonomy node. This covers BOTH applied "
+            "R&D (synthesizing battery electrolytes, designing a "
+            "perovskite PV cell, building a methane-detection sensor) "
+            "AND mechanism / foundational research where the abstract "
+            "names both the mechanism AND a specific solution domain "
+            "it informs (e.g. plant nutrient-sensing for low-fertilizer "
+            "crops, soil-microbe interactions for carbon stabilization, "
+            "computational methods explicitly for clean-energy materials). "
+            "Most research-grant abstracts that match the taxonomy "
+            "fall in this mode."
+        ),
+    },
+    {
+        "name": "indirect",
+        "definition": (
+            "the project produces field-building infrastructure or "
+            "soft levers for the climate field — climate-science "
+            "instrumentation that supports many solutions, satellite "
+            "monitoring, lifecycle assessments, multi-pillar policy / "
+            "regulatory analysis, capacity-building research, "
+            "education / outreach research. Typically Cross-Cutting; "
+            "use this mode when the research output is a tool or "
+            "framework rather than the development of a specific "
+            "named solution."
+        ),
+    },
+]
+
+ONEEARTH_RESEARCH_RULE_OVERRIDES = {
+    "domain_relevance": (
+        "Climate-action relevance for research. Match a candidate when "
+        "the abstract names a research activity (development, "
+        "validation, characterization, modeling, mechanism "
+        "investigation, field demonstration) on the candidate's "
+        "domain. The taxonomy already establishes the climate "
+        "mechanism for each candidate — your job is to decide whether "
+        "the abstract names the research activity that maps to the "
+        "candidate, not to re-derive whether the underlying solution "
+        "helps stabilize the climate.\n"
+        "Important: inclusions below grant entry at the Pillar / "
+        "Sub-Pillar level only. Selecting a specific Solution or "
+        "Sub-Term still requires the abstract to name that specific "
+        "research target — see the specificity rule.\n"
+        "- Research on ecosystem protection or restoration (forests, "
+        "grasslands, wetlands, peatlands, mangroves, coastal habitats, "
+        "watersheds, coral reefs, urban green infrastructure) counts "
+        "as a Nature Conservation match even when the abstract does "
+        "not say 'carbon' or 'GHG' — the carbon-sink mechanism is "
+        "established by the taxonomy itself.\n"
+        "- Research on climate-data, analytics, risk-modeling, "
+        "monitoring, satellite observation, and geospatial tools "
+        "counts as field_building / Cross-Cutting when the work "
+        "supports many solutions rather than one.\n"
+        "- Research on local food systems, agroecology, or food-system "
+        "transformation counts as Regenerative Agriculture at the "
+        "Pillar / Sub-Pillar level when sustainable practices are "
+        "named as the research target.\n"
+        "- Mechanism research counts as a match ONLY when the abstract "
+        "names BOTH (a) the mechanism / method, AND (b) a specific "
+        "solution-domain that depends on it. Plant biology that names "
+        "'breeding low-fertilizer crops' as the application is a "
+        "match; plant biology with no named application is NOT a "
+        "match.\n"
+        "Out of scope: research that mentions climate vocabulary in "
+        "passing without making it the project's research target; "
+        "biology / chemistry / medicine that uses 'carbon' or 'CO2' in "
+        "non-atmospheric contexts (medical CO2 removal, organic "
+        "carbon chemistry unrelated to atmospheric carbon, biological "
+        "respiration); pure curiosity-driven science with no named "
+        "solution; basic-impact statements that name 'sustainability' "
+        "as a downstream possibility without making it a research "
+        "target; conferences, symposia, training grants, workforce "
+        "programs; thin USAspending stub records that describe "
+        "funding mechanisms (IRA / IIJA / 5339(C)) without naming a "
+        "research activity. When the abstract is too thin to commit "
+        "to even a Pillar, return `matches: []`."
+    ),
+    "cross_sector": (
+        "No cross-pillar inference, and no Cross-Cutting fallback. "
+        "Assign a Pillar only if the project itself investigates, "
+        "develops, or validates the climate activity in that Pillar. "
+        "A research project that develops a low-emission INPUT used by "
+        "another sector stays in its own primary Pillar — it does not "
+        "get pulled into the destination sector's Pillar — unless the "
+        "abstract says the project also investigates that destination.\n"
+        "TWO DISTINCT SENSES of 'cross-cutting' exist in this taxonomy "
+        "— do not conflate them:\n"
+        "  (A) Top-level Cross-Cutting Pillar — for projects whose work "
+        "      genuinely spans multiple PRIMARY PILLARS (Energy "
+        "      Transition × Nature Conservation × Regenerative "
+        "      Agriculture × Geo-Engineering). Examples: integrated "
+        "      land-energy system modeling that combines forest carbon "
+        "      with renewable siting; a climate finance platform that "
+        "      funds both Reg Ag and Energy Transition work; satellite "
+        "      monitoring that serves both Nature Conservation AND "
+        "      Energy Transition use cases. The defining test: list "
+        "      the primary pillars the project's stated work touches. "
+        "      If that list has >= 2 entries, top-level Cross-Cutting "
+        "      may fit.\n"
+        "  (B) Cross-Cutting Sub-Pillars inside one primary pillar "
+        "      (Cross-Cutting Energy / Cross-Cutting Nature / Cross-"
+        "      Cutting Regen Ag) — for projects that span multiple "
+        "      SOLUTIONS within ONE primary pillar, or that build the "
+        "      field for that pillar. Per the taxonomy definitions:\n"
+        "      • Cross-Cutting Regen Ag spans multiple Regen Ag "
+        "        Solutions (regenerative croplands, sustainable "
+        "        rangelands, food waste reduction, circular "
+        "        fibersheds) — including supply-chain tools, food-"
+        "        system data platforms, ag-policy analysis, farmer "
+        "        education / extension that touches several practices, "
+        "        food-system AI institutes, planetarian-diet research, "
+        "        meal-planning / food-waste apps.\n"
+        "      • Cross-Cutting Energy spans multiple energy Solutions "
+        "        (renewable power + renewable heat + renewable transport "
+        "        + energy efficiency) — including grid-modeling that "
+        "        crosses generation modes, cleantech accelerators "
+        "        funding multiple energy solutions, multi-mode "
+        "        decarbonization planning tools.\n"
+        "      • Cross-Cutting Nature spans multiple nature Solutions "
+        "        (land conservation + ocean conservation + ecosystem "
+        "        restoration + wildlife connectivity) — including "
+        "        multi-ecosystem monitoring, multi-habitat policy "
+        "        frameworks, conservation-finance platforms.\n"
+        "DECISION RULE: Before picking top-level Cross-Cutting Pillar, "
+        "identify the primary pillar(s) the project's stated work "
+        "lives in. If the project's scope sits entirely within ONE "
+        "primary pillar's domain (e.g. 'the food system' = Regen Ag; "
+        "'the energy transition' = Energy Transition; 'biodiversity / "
+        "ecosystems' = Nature Conservation), descend into THAT pillar "
+        "and pick its Cross-Cutting Sub-Pillar, NOT the top-level "
+        "Cross-Cutting Pillar. Use top-level Cross-Cutting Pillar only "
+        "when the work genuinely crosses pillar boundaries (e.g., "
+        "energy + nature, energy + agriculture, all-pillar climate "
+        "science).\n"
+        "WITHIN-PILLAR SUB-PILLAR RULE: When a project is a horizontal "
+        "platform within ONE primary pillar — i.e., an institute / "
+        "research center / data platform / AI or ML system / MRV or "
+        "monitoring system / policy framework / financing mechanism / "
+        "supply-chain or systems-level effort — and its stated mission "
+        "targets MULTIPLE Sub-Pillars or multiple Solutions within "
+        "that pillar, route to the pillar's Cross-Cutting Sub-Pillar "
+        "(Cross-Cutting Energy / Cross-Cutting Nature / Cross-Cutting "
+        "Regen Ag) rather than to whichever narrow Sub-Pillar has the "
+        "strongest literal-text match in the abstract. Signals that "
+        "trigger this routing: mission statements that name 2+ "
+        "downstream activities ('breeding AND production AND supply "
+        "chain AND consumer'; 'generation AND transmission AND end-"
+        "use efficiency'; 'multiple ecosystems'); explicit framings "
+        "like 'transform US food systems', 'decarbonize the energy "
+        "system', 'transform biodiversity monitoring'; institute / "
+        "center / consortium scope language; horizontal enabling "
+        "technologies (AI, sensors, digital twins, satellite, finance, "
+        "policy) applied across several levers within the pillar. Do "
+        "NOT collapse such a project onto its narrowest literal match "
+        "(e.g. picking Food Waste Reduction just because the abstract "
+        "lists 'eliminating food waste' as one of four mission goals). "
+        "Conversely, when a project genuinely targets ONLY one named "
+        "lever (one specific solution, one ecosystem, one technology), "
+        "stay at that narrow Sub-Pillar / Solution — do not promote it "
+        "to Cross-Cutting.\n"
+        "A research project on a SPECIFIC named solution belongs to "
+        "that solution's primary Pillar:\n"
+        "- Battery chemistry, EV powertrain, heat-pump, smart-grid, "
+        "or industrial-decarbonization research → Energy Transition "
+        "(NOT Cross-Cutting).\n"
+        "- Wetland-restoration ecology, marine conservation science, "
+        "or land-trust research → Nature Conservation (NOT Cross-"
+        "Cutting).\n"
+        "- Soil microbiome, cover-crop, regenerative-grazing, "
+        "alternative-protein research, food-waste R&D, planetarian-"
+        "diet studies → Regenerative Agriculture (NOT top-level "
+        "Cross-Cutting).\n"
+        "- Low-carbon materials, recycling, or industrial chemistry "
+        "research stays in its primary Pillar (typically Energy "
+        "Transition for industrial decarb), or returns no Pillar "
+        "match if no clean home — it does NOT become top-level "
+        "Cross-Cutting by default.\n"
+        "Pick top-level Cross-Cutting Pillar only when the abstract "
+        "names genuine cross-pillar integration or all-field enabling "
+        "tools. When in doubt between top-level Cross-Cutting and a "
+        "within-pillar Cross-Cutting Sub-Pillar, prefer the within-"
+        "pillar Sub-Pillar."
+    ),
+    "specificity": (
+        "Specificity must match the level. A candidate is selectable "
+        "only when the abstract names a research target specific "
+        "enough to support it. Broad research framing ('renewable "
+        "energy systems', 'climate-resilient agriculture', "
+        "'natural climate solutions', 'sustainable materials', "
+        "'low-carbon chemistry') can support a Pillar but is NOT "
+        "sufficient for a narrower Sub-Pillar, Solution, or Sub-Term "
+        "unless the abstract also names the specific technology, "
+        "ecosystem, organism, or practice the child covers.\n"
+        "Research projects often name their methodology specifically "
+        "(e.g. 'metalloprotein-inspired catalysts for CO2 reduction'). "
+        "The methodology name supports the Solution / Sub-Term level "
+        "when it maps cleanly. When the abstract describes basic "
+        "mechanism research without naming a specific downstream "
+        "solution, leaf at the Pillar / Sub-Pillar — do NOT descend "
+        "without specific evidence.\n"
+        "Energy Transition example: 'renewable energy materials' "
+        "supports the Pillar; selecting Solar PV requires "
+        "solar/photovoltaic/silicon/perovskite or other PV-specific "
+        "terms in the abstract.\n"
+        "Nature Conservation example: 'habitat restoration' or "
+        "'biodiversity conservation' supports the Nature Conservation "
+        "Pillar (and often a broad Sub-Pillar like Land Conservation), "
+        "but does NOT support a specific Solution or Sub-Term. "
+        "Selecting Wetland Restoration requires the abstract to name "
+        "wetlands / salt marsh / mangrove / peatland AND the "
+        "restoration activity. Selecting Species Rewilding requires "
+        "'reintroduces extirpated species'. Selecting Invasive "
+        "Species Management requires 'removes / controls invasive "
+        "species'.\n"
+        "Regenerative Agriculture example: 'sustainable farming' or "
+        "'soil health' supports the Pillar; selecting Cover Crops "
+        "requires 'cover crops' or 'planting cover between cash "
+        "crops'; No-till requires 'no-till' or 'reduced tillage'; "
+        "Agroforestry requires 'integrating trees with crops or "
+        "livestock'.\n"
+        "When in doubt, return `matches: []` and let the walk stop "
+        "one level higher."
+    ),
+    "qualifier_lock": (
+        "Qualifier lock. Qualifiers in a candidate's name are "
+        "mandatory constraints, not flavor — Utility-Scale, "
+        "Distributed, Residential, Onshore, Offshore, Coastal, "
+        "Tropical, Temperate, Boreal, etc. The abstract must support "
+        "the qualifier. If the abstract is silent on the qualifier, "
+        "do NOT select the candidate. Research on 'solar PV' without "
+        "naming utility-scale or distributed deployment supports the "
+        "Solar Solution but neither Sub-Term."
+    ),
+    "prominence": (
+        "Prominence at Pillar and Sub-Pillar levels. The research "
+        "activity must be a substantial focus of the project, not a "
+        "passing mention in the broader-impacts statement. Look for "
+        "the project's stated research aims, methods, and "
+        "deliverables — those should name the candidate's domain. A "
+        "single broader-impacts phrase like 'this work could enable "
+        "sustainable agriculture' or 'broader impacts include "
+        "renewable energy applications' is NOT enough at the Pillar "
+        "level — the project's primary research target must be in "
+        "the candidate's domain.\n"
+        "At deeper levels (Solution / Sub-Term), a specifically "
+        "named research target is sufficient even if briefly "
+        "mentioned, because specificity itself is the signal."
+    ),
+    "advocacy_depth": (
+        "Match depth must reflect the research's scope. A project "
+        "investigating molecular mechanism of nitrogen fixation "
+        "matches at the Sub-Pillar level (Regenerative Croplands) "
+        "unless the abstract names a specific fertilizer-reduction "
+        "practice the work supports. A project on solar-cell "
+        "materials matches at the Solar Solution level unless the "
+        "abstract names utility-scale or distributed deployment. The "
+        "narrower the candidate, the more explicit the abstract "
+        "evidence must be."
+    ),
+}
+
+ONEEARTH_RESEARCH_SYSTEM_PROMPT = build_system_prompt(
+    levels=ONEEARTH_LEVELS,
+    domain_intro=ONEEARTH_RESEARCH_DOMAIN_INTRO,
+    modes=ONEEARTH_RESEARCH_MODES,
+    rules=ONEEARTH_RESEARCH_RULE_OVERRIDES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy loader (custom — handles OE's per-pillar Sub-Term sheets)
+# ---------------------------------------------------------------------------
+
+def load_taxonomy(path: Path) -> dict[int, pd.DataFrame]:
+    """Load the One Earth taxonomy at ``path`` as a level-keyed dict.
+
+    The default ``_htm.load_taxonomy`` reads one sheet per level, but
+    Sub-Terms are split across four per-pillar sheets in the source
+    file. So levels 0–2 are read directly from their named sheets, and
+    level 3 is composed in memory: each per-pillar sheet contributes
+    its rows where ``Sub-Term`` is non-blank, with ``Sub-Term Definition``
+    promoted to ``Definition``. The Cross-Cutting pillar has no per-pillar
+    sheet, so its Solutions appear in level 2 with no level-3 children
+    and the walk leafs at Solution there.
+
+    Rows missing the level's ``key_col`` or ``Definition`` are dropped to
+    keep the prompt clean — same contract as the engine's loader.
+    """
+    tables: dict[int, pd.DataFrame] = {}
+
+    # Levels 0–2: direct read from named sheets.
+    for lvl in ONEEARTH_LEVELS[:3]:
+        df = pd.read_excel(path, sheet_name=lvl["sheet"])
+        df = df.dropna(subset=[lvl["key_col"], "Definition"]).reset_index(drop=True)
+        tables[lvl["idx"]] = df
+
+    # Level 3: concatenate per-pillar sheets and promote Sub-Term Definition.
+    sub_term_frames: list[pd.DataFrame] = []
+    for sheet in PILLAR_DETAIL_SHEETS:
+        sdf = pd.read_excel(path, sheet_name=sheet)
+        # Drop rows with no Sub-Term value.
+        sdf = sdf.dropna(subset=["Sub-Term"]).copy()
+        sdf = sdf[sdf["Sub-Term"].astype(str).str.strip().ne("")]
+        # Drop the solution-level "Definition" so we can promote the
+        # sub-term-level definition under that name.
+        if "Definition" in sdf.columns:
+            sdf = sdf.drop(columns=["Definition"])
+        sdf = sdf.rename(columns={"Sub-Term Definition": "Definition"})
+        # Keep only the columns the walk needs.
+        keep = ["Pillar", "Sub-Pillar", "Solution", "Sub-Term", "Definition"]
+        sdf = sdf[[c for c in keep if c in sdf.columns]]
+        sub_term_frames.append(sdf)
+
+    sub_terms = pd.concat(sub_term_frames, ignore_index=True)
+    sub_terms = sub_terms.dropna(
+        subset=["Pillar", "Sub-Pillar", "Solution", "Sub-Term", "Definition"]
+    )
+    # Dedupe on the (Pillar, Sub-Pillar, Solution, Sub-Term) path so a
+    # Sub-Term that appears in multiple pillar sheets only contributes one
+    # candidate to its parent Solution.
+    sub_terms = sub_terms.drop_duplicates(
+        subset=["Pillar", "Sub-Pillar", "Solution", "Sub-Term"]
+    ).reset_index(drop=True)
+
+    tables[3] = sub_terms
+    return tables
+
+
+def collapse_to_one_row_per_uid(
+    df: pd.DataFrame,
+    id_col: str = "uid",
+) -> pd.DataFrame:
+    """Collapse a per-row OE classification frame to one row per id.
+
+    Thin wrapper over the engine's ``collapse_to_one_row_per_uid`` bound
+    to ``ONEEARTH_LEVELS``. ``id_col`` defaults to ``"uid"`` to match the
+    CFT convention but accepts any column name.
+    """
+    return _htm.collapse_to_one_row_per_uid(df, ONEEARTH_LEVELS, id_col=id_col)
+
+
+# ---------------------------------------------------------------------------
+# High-level mapping entry point
+# ---------------------------------------------------------------------------
+
+_PROMPT_BY_MODE: dict[str, str] = {
+    "organization": ONEEARTH_SYSTEM_PROMPT,
+    "research": ONEEARTH_RESEARCH_SYSTEM_PROMPT,
+}
+
+def build_recovery_scope_prompt(taxonomy_path: Path | None = None) -> str:
+    """Build the second-stage recovery's scope system prompt.
+
+    Reuses the canonical mapping scope (``ONEEARTH_DOMAIN_INTRO`` +
+    ``ONEEARTH_CROSS_PILLAR_ROUTING``) so the recovery and the classifier
+    share one scope source, plus a yes/no instruction. Validated on the
+    seed-42 empties at ~88% accuracy separating in-scope-but-refused from
+    genuinely out-of-scope; the bare-definition scope under-recalls on
+    framing-masked in-scope orgs, so the richer scope is used. ``taxonomy_path``
+    is accepted for signature compatibility but unused (scope is text-based).
+    """
+    return (
+        ONEEARTH_DOMAIN_INTRO + "\n\n" + ONEEARTH_CROSS_PILLAR_ROUTING + "\n\n"
+        + "Decide whether the organization's OWN work is in scope for any "
+        "pillar above (an implicit climate mechanism is acceptable; an "
+        "incidental co-benefit of otherwise out-of-scope work is not). "
+        "Return JSON: {\"in_scope\": true|false, \"pillar\": \"<exact pillar "
+        "name or null>\", \"reason\": \"<one sentence>\"}."
+    )
+
+
+def map_to_oneearth(
+    entities: pd.DataFrame,
+    *,
+    id_col: str,
+    name_col: str,
+    text_col: str,
+    client: OpenAI,
+    model: str = MODEL,
+    max_workers: int = DEFAULT_WORKERS,
+    taxonomy_path: Path | None = None,
+    descent_fanout_cap: int = DESCENT_FANOUT_CAP,
+    prompt_mode: str = "organization",
+    system_prompt: str | None = None,
+    confidence_threshold: float | None = None,
+    emit_per_level: bool = False,
+    recover_unmatched: bool = False,
+    recovery_model: str = "gpt-4.1-mini",
+    recovery_scope_prompt: str | None = None,
+    walk_recovered: bool = False,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Classify a DataFrame of entities against the One Earth taxonomy.
+
+    Top-level convenience for the common case: one DataFrame in,
+    per-row + collapsed DataFrames out. Loads the latest taxonomy,
+    runs the hierarchical walk, and returns both views.
+
+    Parameters
+    ----------
+    entities
+        DataFrame whose rows are the entities to classify. Must contain
+        ``id_col``, ``name_col``, and ``text_col``. Any other columns
+        are carried through to the output DataFrames untouched.
+    id_col
+        Column with a stable per-entity id. Used to group leaf rows in
+        the collapsed view.
+    name_col
+        Column with the entity's name. Shown to the LLM but not used as
+        evidence (see the engine's ``evidence_only`` rule).
+    text_col
+        Column with the entity description. The LLM matches against the
+        text in this column.
+    client
+        An ``openai.OpenAI`` client. Caller supplies it so this library
+        does not depend on a project-specific config-file location.
+    model
+        OpenAI model id. Default ``MODEL`` (currently ``gpt-5.4-nano``).
+    max_workers
+        Thread pool size for parallel classification. The hierarchical
+        walk is I/O-bound on the OpenAI API; large pools (16, 32, 64)
+        are fine. Use 1 for a single-threaded debug path.
+    taxonomy_path
+        Optional override for the taxonomy xlsx. Defaults to
+        ``find_latest_taxonomy()`` which picks the latest VDL-edited
+        ``OE Solutions Terms *VDL.xlsx`` from ``SHARED_TAXONOMY_DIR``.
+    descent_fanout_cap
+        Maximum number of children to descend into when a level returns
+        multiple matches. Default 3.
+    prompt_mode
+        ``"organization"`` (default): the standard OE system prompt,
+        calibrated for organizations (companies, NGOs, land trusts).
+        ``"research"``: a research-project variant that swaps domain
+        intro, modes-of-operation, and rule overrides as a coordinated
+        triple — framed for grant abstracts (NSF, NIH, USAspending).
+        Same taxonomy and walk, different framing. The three pieces
+        move together; mixing org and research framing produces
+        incoherent prompts. Ignored when ``system_prompt`` is set.
+    system_prompt
+        Escape hatch for callers that want to assemble a fully custom
+        system prompt via ``build_system_prompt``. When provided, it
+        overrides ``prompt_mode`` entirely.
+    confidence_threshold
+        Precision/recall knob in [0, 1]. When set, the ``system_prompt``
+        must be confidence-enabled (``build_system_prompt(
+        include_confidence=True)``); the model emits a per-match
+        confidence and matches below the threshold are dropped. LOWER
+        keeps more (weaker) matches — fewer no-mappings, more false
+        positives; HIGHER keeps only strong matches. ``None`` (default)
+        applies no confidence scoring or filtering.
+    emit_per_level
+        When True, the per-row frame gains ``<level> evidence`` /
+        ``<level> reason`` / ``<level> confidence`` columns for every
+        assignment along each path, not just the deepest match.
+    walk_recovered
+        When True (requires ``recover_unmatched=True``), entities the walk
+        left empty but the recovery marked in scope get a second walk
+        seeded at the recovered pillar, descending into Sub-Pillar /
+        Solution / Sub-Term where the description supports it. Their
+        placeholder rows are replaced by the seeded leaf rows; the
+        ``recovery_*`` columns carry through, so the rows remain flagged
+        as recovery-sourced.
+
+    Returns
+    -------
+    (per_row_df, collapsed_df)
+        ``per_row_df`` has one row per (entity, leaf) pair, with columns
+        ``id_col``, ``name_col``, ``text_col``, all the entity's other
+        columns, then ``Pillar`` / ``Sub-Pillar`` / ``Solution`` /
+        ``Sub-Term``, ``deepest_match``, ``leaf_definition``,
+        ``mode_of_operation``, ``evidence``, ``reason``.
+
+        ``collapsed_df`` has one row per id, with each level rendered as
+        a repr-encoded list of unique values per entity, plus the
+        deepest non-empty level name in ``deepest_match`` (or
+        ``"NoMatch"``). Non-classification columns from the input are
+        carried through using each id's first non-null value.
+    """
+    if walk_recovered and not recover_unmatched:
+        raise ValueError("walk_recovered=True requires recover_unmatched=True")
+
+    if taxonomy_path is None:
+        taxonomy_path = find_latest_taxonomy()
+    tables = load_taxonomy(taxonomy_path)
+
+    if system_prompt is None:
+        if confidence_threshold is not None and prompt_mode == "organization":
+            # The confidence knob needs the confidence-enabled schema.
+            system_prompt = build_oneearth_system_prompt(include_confidence=True)
+        elif prompt_mode not in _PROMPT_BY_MODE:
+            raise ValueError(
+                f"Unknown prompt_mode {prompt_mode!r}; expected one of "
+                f"{sorted(_PROMPT_BY_MODE)} or pass system_prompt= explicitly."
+            )
+        else:
+            system_prompt = _PROMPT_BY_MODE[prompt_mode]
+
+    per_row_df = classify_entities(
+        client=client,
+        tables=tables,
+        levels=ONEEARTH_LEVELS,
+        system_prompt=system_prompt,
+        entities=entities,
+        id_col=id_col,
+        name_col=name_col,
+        text_col=text_col,
+        model=model,
+        descent_fanout_cap=descent_fanout_cap,
+        max_workers=max_workers,
+        confidence_threshold=confidence_threshold,
+        emit_per_level=emit_per_level,
+    )
+    if recover_unmatched:
+        # Default top-level column + category choices from the level spec +
+        # tables; override only the scope prompt with the OE-specific rich one.
+        per_row_df = _htm.recover_unmatched(
+            per_row_df,
+            client=client,
+            model=recovery_model,
+            id_col=id_col,
+            name_col=name_col,
+            text_col=text_col,
+            levels=ONEEARTH_LEVELS,
+            tables=tables,
+            scope_prompt=recovery_scope_prompt or build_recovery_scope_prompt(
+                taxonomy_path),
+            max_workers=max_workers,
+        )
+
+    if walk_recovered:
+        per_row_df = _walk_recovered_entities(
+            per_row_df, client=client, tables=tables, system_prompt=system_prompt,
+            id_col=id_col, name_col=name_col, text_col=text_col, model=model,
+            descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
+            confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
+        )
+
+    collapsed_df = collapse_to_one_row_per_uid(per_row_df, id_col=id_col)
+    return per_row_df, collapsed_df
+
+
+def _walk_recovered_entities(
+    per_row_df: pd.DataFrame, *, client, tables, system_prompt, id_col, name_col,
+    text_col, model, descent_fanout_cap, max_workers, confidence_threshold,
+    emit_per_level,
+) -> pd.DataFrame:
+    """Seed the walk at each recovery-recovered entity's pillar and descend.
+
+    Entities the walk left empty but the recovery marked in-scope (with a
+    pillar) get a second walk seeded at that pillar, picking up Sub-Pillar /
+    Solution / Sub-Term where the description supports it. Their placeholder
+    (no-match) rows are replaced by the seeded leaf rows; the recovery
+    columns carry through, so these rows stay flagged as recovery-sourced.
+    Entities that stay pillar-only after the descent keep the assigned pillar.
+    """
+    top_col = ONEEARTH_LEVELS[0]["output_col"]
+    recovered_col = f"recovered_{top_col}"
+    if recovered_col not in per_row_df.columns:
+        return per_row_df
+
+    is_recovered = (
+        per_row_df[top_col].isna()
+        & (per_row_df["recovered_in_scope"] == True)  # noqa: E712
+        & per_row_df[recovered_col].notna()
+    )
+    rec_ids = per_row_df.loc[is_recovered, id_col].unique()
+    if len(rec_ids) == 0:
+        return per_row_df
+
+    # One entity row per recovered id; strip the classification columns so the
+    # seeded walk regenerates them (carry cols incl. recovery_* are kept).
+    class_cols = (
+        [lvl["output_col"] for lvl in ONEEARTH_LEVELS]
+        + ["deepest_match", "leaf_definition", "mode_of_operation",
+           "evidence", "reason", "confidence"]
+    )
+    for lvl in ONEEARTH_LEVELS:
+        oc = lvl["output_col"]
+        class_cols += [f"{oc} evidence", f"{oc} reason", f"{oc} confidence"]
+    seed_input = (per_row_df[per_row_df[id_col].isin(rec_ids)]
+                  .drop_duplicates(id_col)
+                  .drop(columns=[c for c in class_cols if c in per_row_df.columns]))
+
+    seeded = classify_entities(
+        client=client, tables=tables, levels=ONEEARTH_LEVELS,
+        system_prompt=system_prompt, entities=seed_input, id_col=id_col,
+        name_col=name_col, text_col=text_col, model=model,
+        descent_fanout_cap=descent_fanout_cap, max_workers=max_workers,
+        confidence_threshold=confidence_threshold, emit_per_level=emit_per_level,
+        seed_col=recovered_col,
+    )
+
+    kept = per_row_df[~per_row_df[id_col].isin(rec_ids)]
+    merged = pd.concat([kept, seeded.reindex(columns=per_row_df.columns)],
+                       ignore_index=True)
+    return merged
+
+
+# Re-exports for callers that want to drive the engine directly.
+__all__ = [
+    "MODEL",
+    "DESCENT_FANOUT_CAP",
+    "DEFAULT_WORKERS",
+    "SHARED_TAXONOMY_DIR",
+    "PILLAR_DETAIL_SHEETS",
+    "ONEEARTH_LEVELS",
+    # Organization-tuned prompt (default).
+    "ONEEARTH_DOMAIN_INTRO",
+    "ONEEARTH_MODES",
+    "ONEEARTH_RULE_OVERRIDES",
+    "ONEEARTH_SYSTEM_PROMPT",
+    # Research-project-tuned prompt (prompt_mode="research").
+    "ONEEARTH_RESEARCH_DOMAIN_INTRO",
+    "ONEEARTH_RESEARCH_MODES",
+    "ONEEARTH_RESEARCH_RULE_OVERRIDES",
+    "ONEEARTH_RESEARCH_SYSTEM_PROMPT",
+    "find_latest_taxonomy",
+    "load_taxonomy",
+    "collapse_to_one_row_per_uid",
+    "map_to_oneearth",
+    # Engine re-exports
+    "build_system_prompt",
+    "classify_entities",
+    "classify_entity",
+]


### PR DESCRIPTION
## Summary

Three connected changes to the `vdl_tools/shared_tools/taxonomy_mapping/` engines:

1. **Migrate every OpenAI call to the SQL prompt-response cache.** `hierarchical_taxonomy_mapping`, `check_taxonomy_coherence`, and `hierarchical_taxonomy_judge` now take a SQLAlchemy `session=` instead of an `openai.OpenAI` client, build their per-call work into `bulk_get_cache_or_run` batches against new `InstructorPRC` subclasses (`TaxonomyMatchCache`, `ScopeRecoveryCache`, `CoherenceAuditCache`, `JudgeCache`), and use Pydantic structured outputs via `responses.parse` instead of `chat.completions` + raw JSON mode. Re-running an unchanged pipeline is now a no-API run after the first successful pass.

2. **Per-project `match_schema` for the classifier.** `build_system_prompt` and `classify_entities` accept a Pydantic `match_schema` kwarg. When provided, it drives both the prompt's JSON shape description AND the API-layer strict-mode enforcement (via `TaxonomyMatchCache.response_model`), so the prompt prose and the structural constraint can't drift apart. Drivers define their own minimal `Match`/`MatchesResponse` classes:
   - **OE** uses `OneEarthMatch` (mode_of_operation as `Literal["direct", "enabling tech", "indirect"]`) and a confidence variant for the `confidence_threshold` knob.
   - **ED-tracker** uses `EdMatch` — index/evidence/reason only — because the ed taxonomy prompt has no modes and no confidence. This stops OpenAI strict-mode from forcing the model to emit `mode_of_operation`, which would spuriously trigger the indirect-fanout-stop and shorten walks. Default `MatchesResponse` is unchanged so any caller that doesn't opt in keeps working.

3. **Restore `temperature=0`.** The legacy `client.chat.completions.create` path set it explicitly; the new path was running at OpenAI's default (1.0) for non-reasoning models. `classify_entities` and `recover_unmatched` now take `temperature: float | None = 0`, threaded into `bulk_get_cache_or_run` via `**api_kwargs`. Automatically suppressed for reasoning models (`gpt-5*`) which reject the param.

Drop-in for OE / ED-tracker / Drawdown drivers; existing callers that don't pass `match_schema=` get the same `MatchesResponse` as before.

## What changed

| File | Change |
|---|---|
| `taxonomy_mapping/taxonomy_mapping_cache.py` | **New.** Pydantic schemas (`MatchesResponse`, `ScopeDecision`) + `InstructorPRC` subclasses (`TaxonomyMatchCache`, `ScopeRecoveryCache`). `TaxonomyMatchCache` accepts `response_model=` for per-project schemas. |
| `taxonomy_mapping/hierarchical_taxonomy_mapping.py` | Bulk-per-level rewrite of `classify_entities`. New helpers `_build_user_text`, `_build_given_id`, `_clean_matches`, `_seed_branch`. `recover_unmatched` migrated. `match_schema=` + `temperature=` kwargs threaded through. `_clean_matches` uses `getattr` so schemas without `mode_of_operation` / `confidence` work. Drops `build_openai_client`. |
| `taxonomy_mapping/check_taxonomy_coherence.py` | `AuditResponse` + `Gap` Pydantic schemas, `CoherenceAuditCache(InstructorPRC)`. `check_taxonomy_coherence` takes `session=` and uses a single bulk call. Drops `_audit_one` and the threadpool. |
| `taxonomy_mapping/hierarchical_taxonomy_judge.py` | `MatchScore`, `LevelMatches`, `AlignmentVerdict`, `JudgmentResponse` schemas + `JudgeCache(InstructorPRC)`. `run_judge_evaluation` takes `session=` and uses a single bulk call. Schema shape is now a stable list-of-LevelMatches (vs the old dynamic `<verdict_top_label>_alignment` key) so structured output works across configs. `JudgeConfig` drops `build_openai_client` + `verdict_key`. |
| `taxonomy_mapping/oe_hierarchical_taxonomy_mapping.py` | `map_to_oneearth` and `_walk_recovered_entities` take `session=` (drop `client=`). Adds `OneEarthMatch[WithConfidence]` schemas + `oneearth_match_schema()` factory; `build_oneearth_system_prompt` and `ONEEARTH_RESEARCH_SYSTEM_PROMPT` pass `match_schema=` based on `include_confidence`. Recovery scope prompt's JSON field renamed from `pillar` to `category` to match `ScopeDecision`. |
| `openai/prompt_response_cache_sql.py` | One-line touch (a default kwarg fix from a sibling PR). |

## Compatibility / migration

- `build_openai_client` is removed from `hierarchical_taxonomy_mapping` and `JudgeConfig`. Callers must use `with get_session() as session:` and pass `session=`. The ED-tracker and Drawdown drivers (in their own repos) have already been updated.
- Coherence engine signature: `check_taxonomy_coherence(client=...)` → `check_taxonomy_coherence(session=...)`. ED-tracker and Drawdown coherence-check drivers already updated.
- Judge JSON output key changed from `<pillar>_alignment` to `alignment_verdict` (and `matches` is now a list of `{level, matches: [...]}` instead of a dict keyed by level). Downstream DataFrame columns are unchanged, so reports and aggregates carry through transparently. Existing cached judge responses from before this PR are invalidated by the new `prompt_id` (new system prompt + new Pydantic schema).

## Quality check

Judged a 464-uid subset (intersection of a new 500-entity sample + the 2026_04_17 ed_tracker baseline) with the same `JudgeConfig`:

- **98.0% of shared (entity, level, match) score points unchanged**.
- **94.8% of verdicts unchanged**.
- Net verdict change: **+9 `correct`** (mostly from previously-refused entities the new pipeline now classifies; 11 of the 12 verdict scope-flips are `no_pillar_expected → correct`).
- 7-entity verdict regression and 15 small score regressions (vs 14 improvements) on 1,451 shared keys — within noise.
- Pillar-level mean score: 0.9753 → 0.9599 (small dip; trade-off for the increased recall).

## Test plan

- [ ] Run a small slice (~50 entities) through OE `map_to_oneearth` via a fresh session and confirm the per-row frame shape matches the legacy schema (`Pillar / Sub-Pillar / Solution / Sub-Term` + `deepest_match / leaf_definition / mode_of_operation / evidence / reason / confidence`).
- [ ] Run the same slice with `read_from_cache=False` and confirm fresh API calls populate the cache; re-run and confirm 100% cache hit (zero API calls).
- [ ] Run ED-tracker driver with `match_schema=EdMatchesResponse`; confirm `mode_of_operation` column in the per-row output is empty for every row (schema doesn't include the field → model can't emit it).
- [ ] Run the coherence checker on a small taxonomy and confirm the audit DataFrame matches the legacy column shape.
- [ ] Run the judge on a small per-row file and confirm `_quality_scored.xlsx`, `_quality_<top>_verdicts.xlsx`, `_quality_summary.xlsx`, and `_quality_report.md` are written.
- [ ] Confirm reasoning models (`gpt-5*`) work without errors — the `temperature` kwarg should be suppressed automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)