### PR TITLE
parquet_cache: full-scan fallback for deep mixed-type object columns

### DIFF
--- a/vdl_tools/shared_tools/parquet_cache.py
+++ b/vdl_tools/shared_tools/parquet_cache.py
@@ -118,6 +118,28 @@ def _scan_columns(df: pd.DataFrame) -> tuple[list[str], list[str]]:
     return json_cols, mixed_cols
 
 
+def _scan_columns_full(df: pd.DataFrame) -> tuple[list[str], list[str]]:
+    """Like :func:`_scan_columns` but scans ALL non-null values, not just a sample.
+
+    Used only on the ``from_pandas`` exception path, so the O(rows) cost is paid
+    rarely — it catches columns that are type-consistent in their first
+    ``_SAMPLE_SIZE`` values but mixed deeper (a stray ``int`` or a buried
+    dict/list past the sampling window).
+    """
+    json_cols, mixed_cols = [], []
+    for col in df.columns:
+        if df[col].dtype != object:
+            continue
+        types = {type(v) for v in df[col].to_numpy() if not _is_null(v)}
+        if not types:
+            continue
+        if types & {dict, list, tuple}:
+            json_cols.append(col)
+        elif len(types) > 1:
+            mixed_cols.append(col)
+    return json_cols, mixed_cols
+
+
 def _is_null(v) -> bool:
     return v is None or (isinstance(v, float) and math.isnan(v))
 
@@ -186,7 +208,26 @@ def write_dataframe(
         for col in mixed_cols:
             df[col] = df[col].map(_to_string)
 
-    table = pa.Table.from_pandas(df, preserve_index=False)
+    try:
+        table = pa.Table.from_pandas(df, preserve_index=False)
+    except (pa.ArrowTypeError, pa.ArrowInvalid):
+        # Sampled scan missed a type-inconsistent column (a stray int or a
+        # buried dict/list past _SAMPLE_SIZE). Re-classify with a full scan,
+        # coerce only the columns the sampled pass missed, and retry once.
+        json2, mixed2 = _scan_columns_full(df)
+        json2 = [c for c in json2 if c not in json_cols]
+        mixed2 = [c for c in mixed2 if c not in mixed_cols]
+        logger.warning(
+            "Sampled scan missed type-inconsistent columns; full-scan coercing "
+            "json=%s mixed=%s and retrying", json2, mixed2)
+        df = df.copy()  # first pass only copied if it found something to coerce
+        for col in json2:
+            df[col] = df[col].map(_encode_json)
+            json_cols.append(col)  # keep _JSON_COLS_KEY metadata accurate
+        for col in mixed2:
+            df[col] = df[col].map(_to_string)
+        table = pa.Table.from_pandas(df, preserve_index=False)
+
     meta = dict(table.schema.metadata or {})
     meta[_JSON_COLS_KEY] = json.dumps(json_cols).encode()
     meta[_LINEAGE_KEY] = json.dumps(

--- a/vdl_tools/shared_tools/tests/test_parquet_cache.py
+++ b/vdl_tools/shared_tools/tests/test_parquet_cache.py
@@ -1,0 +1,77 @@
+"""Tests for parquet_cache.write_dataframe robustness to deep mixed-type columns.
+
+Covers the sampling blind spot: an object column that is type-consistent in its
+first ``_SAMPLE_SIZE`` non-null values but mixed (or JSON) deeper. The sampled
+scan misses it, ``pa.Table.from_pandas`` raises, and the full-scan fallback must
+coerce and retry.
+"""
+
+import logging
+
+import pandas as pd
+import pytest
+
+from vdl_tools.shared_tools import parquet_cache as pqc
+
+
+@pytest.fixture()
+def path(tmp_path):
+    return str(tmp_path / "frame.parquet")
+
+
+@pytest.fixture()
+def vdl_logs(caplog):
+    """Capture records from the vdl_tools logger, which has ``propagate=0`` and
+    so never reaches caplog's root handler on its own."""
+    pqc.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger=pqc.logger.name)
+    try:
+        yield caplog
+    finally:
+        pqc.logger.removeHandler(caplog.handler)
+
+
+def test_deep_mixed_scalar_column(path, vdl_logs):
+    """A stray int past the 100-sample window coerces to string and round-trips."""
+    values = ["2015"] * 150 + [2016]  # int at index 150, past _SAMPLE_SIZE=100
+    df = pd.DataFrame({"founded": values})
+
+    pqc.write_dataframe(df, path)
+
+    assert "full-scan coercing" in vdl_logs.text  # fallback fired
+
+    out = pqc.read_dataframe(path)
+    assert list(out["founded"]) == ["2015"] * 150 + ["2016"]
+    assert out["founded"].map(type).eq(str).all()
+
+
+def test_deep_json_column(path):
+    """A dict buried past the 100-sample window is JSON-encoded and decodes back."""
+    values = ["x"] * 150 + [{"a": 1}]  # dict at index 150, past _SAMPLE_SIZE
+    df = pd.DataFrame({"payload": values})
+
+    pqc.write_dataframe(df, path)
+
+    out = pqc.read_dataframe(path)
+    assert out["payload"].iloc[:150].tolist() == ["x"] * 150
+    assert out["payload"].iloc[150] == {"a": 1}
+
+
+def test_fast_path_not_triggered(path, vdl_logs):
+    """A clean, type-consistent frame writes without hitting the fallback."""
+    df = pd.DataFrame(
+        {
+            "year": ["2015"] * 200,
+            "count": list(range(200)),
+            "tags": [["a", "b"]] * 200,  # clean JSON column, handled up front
+        }
+    )
+
+    pqc.write_dataframe(df, path)
+
+    assert "full-scan coercing" not in vdl_logs.text  # fallback never fired
+
+    out = pqc.read_dataframe(path)
+    assert list(out["year"]) == ["2015"] * 200
+    assert list(out["count"]) == list(range(200))
+    assert out["tags"].iloc[0] == ["a", "b"]


### PR DESCRIPTION
## Problem

`write_dataframe` crashes with `pyarrow.lib.ArrowTypeError: Expected bytes, got a 'int' object` when an object column holds mixed Python scalar types (e.g. a Crunchbase `founded` column with mostly year-strings and a stray `int`). Surfaced on a 32k-row `ed_tracker` full-pool write.

## Root cause

`_scan_columns` only samples the first `_SAMPLE_SIZE = 100` non-null values per column. A column that is type-consistent in its first 100 values but mixed deeper (the stray `int` sits past row 100) is never flagged, so it isn't coerced. `pa.Table.from_pandas` then scans the whole column and raises. It's a sampling blind spot, not a missing feature.

## Fix

Fast path stays sampled; correct on failure:

- Wrap `pa.Table.from_pandas` in `try/except`.
- On `ArrowTypeError`/`ArrowInvalid`, run a full-scan re-classification of object columns (new `_scan_columns_full`, no `head` limit), coerce **only** the columns the sampled pass missed (reusing `_encode_json`/`_to_string`), and retry once. Re-raise if it still fails.
- Fallback-detected json cols are appended to `json_cols` so the `_JSON_COLS_KEY` footer metadata stays accurate for round-trip decoding.
- `df = df.copy()` on the fallback path (safe whether or not the first pass already copied).

The O(rows × object-cols) cost is paid only on the rare failure, not on every write. `_SAMPLE_SIZE = 100` is unchanged.

## Tests

New `vdl_tools/shared_tools/tests/test_parquet_cache.py`:
1. **Deep mixed** — `["2015"]*150 + [2016]` → fallback fires, round-trips as all-string.
2. **Deep JSON** — `["x"]*150 + [{"a":1}]` → round-trips as decoded objects.
3. **Fast path** — clean frame writes with no fallback warning.

A `vdl_logs` fixture attaches `caplog.handler` to the `vdl_tools` logger (which has `propagate=0`) so warnings are captured.

## Follow-up (separate)

Once this ships and the `vdl-tools` pin is bumped, remove the stopgap `_coerce_mixed_object_cols` and its call in `ed_tracker_ph1/process_enrich.py` (branch `migrate-taxonomy-hierarchical-classifier`) — the central guard makes it redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)