### PR TITLE
Add json_cache with S3 local-filecache; extract shared cache backend

### DIFF
--- a/vdl_tools/shared_tools/_s3_cache_backend.py
+++ b/vdl_tools/shared_tools/_s3_cache_backend.py
@@ -90,5 +90,10 @@ def write_target(uri: str) -> dict:
         if not bucket_exists(bucket):
             create_bucket(get_s3_client(), bucket)
         return {"s3": s3_creds()}
-    Path(uri).parent.mkdir(parents=True, exist_ok=True)
+    # Local target: ensure the parent dir exists. Strip a ``file://`` scheme
+    # first — ``Path("file:///a/b")`` is a *relative* path rooted at ``file:``,
+    # so ``.parent.mkdir`` would spray a junk ``file:`` tree into the cwd
+    # instead of creating the real parent.
+    local_path = uri[len("file://"):] if uri.startswith("file://") else uri
+    Path(local_path).parent.mkdir(parents=True, exist_ok=True)
     return {}

--- a/vdl_tools/shared_tools/_s3_cache_backend.py
+++ b/vdl_tools/shared_tools/_s3_cache_backend.py
@@ -1,0 +1,94 @@
+"""Shared S3 + local-filecache plumbing for the ``*_cache`` modules.
+
+This is the storage-agnostic core extracted from :mod:`parquet_cache`: URI
+detection, AWS credential resolution, the ETag-validated local filecache used
+for ``s3://`` reads, and bucket/parent-dir creation on write. Both
+:mod:`parquet_cache` and :mod:`json_cache` build on it so the credential and
+caching behaviour never drifts between them.
+
+Not a public API — import the ``parquet_cache`` / ``json_cache`` wrappers
+instead.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from vdl_tools.shared_tools.tools.config_utils import get_configuration
+from vdl_tools.shared_tools.s3_tools import get_s3_client, create_bucket, bucket_exists
+
+
+# Root for all vdl-tools caches; each module gets its own subdir underneath.
+DEFAULT_CACHE_ROOT = Path(
+    os.environ.get("VDL_CACHE_DIR", Path.home() / ".cache" / "vdl-tools")
+)
+
+
+def is_s3(uri: str) -> bool:
+    return uri.startswith("s3://")
+
+
+def bucket_of(uri: str) -> str:
+    """``s3://bucket/key`` -> ``bucket``."""
+    return uri.split("/")[2]
+
+
+def s3_creds() -> dict:
+    """Read AWS creds from config.ini ``[aws]``. Empty dict -> boto3 default chain."""
+    try:
+        aws = get_configuration()["aws"]
+    except Exception:
+        return {}
+    opts: dict = {}
+    if aws.get("access_key_id"):
+        opts["key"] = aws["access_key_id"]
+    if aws.get("secret_access_key"):
+        opts["secret"] = aws["secret_access_key"]
+    if aws.get("region"):
+        opts["client_kwargs"] = {"region_name": aws["region"]}
+    return opts
+
+
+def read_target(
+    uri: str,
+    use_cache: bool,
+    cache_dir: Path,
+    check_remote: bool,
+) -> tuple[str, dict]:
+    """Return ``(effective_uri, fsspec_opts)`` for reading from ``uri``.
+
+    Local paths read directly. ``s3://`` paths with ``use_cache`` go through a
+    ``filecache`` that HEAD-checks the remote ETag on every open (``check_remote``),
+    so a concurrent writer's new version invalidates the local copy.
+    """
+    if not is_s3(uri):
+        return uri, {}
+    if not use_cache:
+        return uri, {"s3": s3_creds()}
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return f"filecache::{uri}", {
+        "filecache": {
+            "cache_storage": str(cache_dir),
+            "check_files": check_remote,  # ETag HEAD on every open
+            "expiry_time": None,          # no TTL — rely on ETag check
+            "same_names": False,
+        },
+        "s3": s3_creds(),
+    }
+
+
+def write_target(uri: str) -> dict:
+    """Prepare ``uri`` for writing and return fsspec opts.
+
+    For ``s3://`` targets, create the bucket if it is missing. For local
+    targets, create the parent directory. Returns the fsspec ``open`` kwargs.
+    """
+    if is_s3(uri):
+        bucket = bucket_of(uri)
+        if not bucket_exists(bucket):
+            create_bucket(get_s3_client(), bucket)
+        return {"s3": s3_creds()}
+    Path(uri).parent.mkdir(parents=True, exist_ok=True)
+    return {}

--- a/vdl_tools/shared_tools/json_cache.py
+++ b/vdl_tools/shared_tools/json_cache.py
@@ -43,8 +43,8 @@ _SIDECAR_SUFFIX = ".vdl.json"
 
 
 def _compression(uri: str) -> str | None:
-    """gzip iff the path ends in ``.gz`` — otherwise raw JSON."""
-    return "gzip" if uri.endswith(".gz") else None
+    """gzip iff the path ends in ``.gz`` / ``.gzip`` — otherwise raw JSON."""
+    return "gzip" if uri.endswith((".gz", ".gzip")) else None
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ def write_json(
         ``str`` (matching :mod:`parquet_cache`).
     uri
         Destination. Local path (``str`` or ``Path``), ``file://`` URI, or full
-        ``s3://`` URI including bucket. A ``.gz`` suffix triggers gzip.
+        ``s3://`` URI including bucket. A ``.gz`` / ``.gzip`` suffix triggers gzip.
     lineage
         Optional JSON-serializable dict written to a sidecar
         (``{uri}.vdl.json``) with an auto-added ``created_at``. Retrieve via
@@ -117,8 +117,8 @@ def read_json(
     Parameters
     ----------
     uri
-        Source. Local path, ``file://`` URI, or full ``s3://`` URI. ``.gz`` is
-        decompressed transparently.
+        Source. Local path, ``file://`` URI, or full ``s3://`` URI. ``.gz`` /
+        ``.gzip`` is decompressed transparently.
     use_cache
         If False, skip the local cache and read straight from S3 every time.
     cache_dir

--- a/vdl_tools/shared_tools/json_cache.py
+++ b/vdl_tools/shared_tools/json_cache.py
@@ -1,0 +1,223 @@
+"""JSON I/O with transparent local caching for S3 reads.
+
+The JSON counterpart to :mod:`parquet_cache`. Same storage backend, same cache
+semantics — a drop-in easy way to read/write JSON to local paths, ``file://``,
+or ``s3://`` with the remote reads cached locally and ETag-validated on every
+open (no silent stale reads).
+
+Two things differ from Parquet, both because plain JSON has no footer:
+
+- **Data files stay pure JSON.** The bytes on disk / in S3 are exactly what
+  ``json.dumps`` produced, so a public ``s3://`` object can be fetched straight
+  into a browser or ``curl | jq``. Optional ``lineage`` is written to a small
+  sidecar (``{uri}.vdl.json``) — never mixed into the data — and read back via
+  :func:`get_lineage`.
+- **Compression is chosen by extension.** ``…​.json`` is written raw;
+  ``…​.json.gz`` is gzipped (JSON compresses ~10x — worth it for internal
+  blobs; keep ``.json`` for anything a frontend fetches directly, since fsspec
+  writes no ``Content-Encoding`` header).
+
+Cache dir defaults to ``~/.cache/vdl-tools/json``; override with
+``VDL_JSON_CACHE_DIR`` or by passing ``cache_dir=``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import fsspec
+
+from vdl_tools.shared_tools.tools.logger import logger
+from vdl_tools.shared_tools import _s3_cache_backend as _b
+
+
+DEFAULT_CACHE_DIR = Path(
+    os.environ.get("VDL_JSON_CACHE_DIR", _b.DEFAULT_CACHE_ROOT / "json")
+)
+
+_SIDECAR_SUFFIX = ".vdl.json"
+
+
+def _compression(uri: str) -> str | None:
+    """gzip iff the path ends in ``.gz`` — otherwise raw JSON."""
+    return "gzip" if uri.endswith(".gz") else None
+
+
+# ---------------------------------------------------------------------------
+# Public API — single file
+# ---------------------------------------------------------------------------
+
+def write_json(
+    obj: Any,
+    uri: str | Path,
+    *,
+    lineage: dict | None = None,
+    indent: int | None = None,
+) -> str:
+    """Write ``obj`` as JSON to ``uri``.
+
+    Parameters
+    ----------
+    obj
+        Any JSON-serializable value. Non-serializable leaves fall back to
+        ``str`` (matching :mod:`parquet_cache`).
+    uri
+        Destination. Local path (``str`` or ``Path``), ``file://`` URI, or full
+        ``s3://`` URI including bucket. A ``.gz`` suffix triggers gzip.
+    lineage
+        Optional JSON-serializable dict written to a sidecar
+        (``{uri}.vdl.json``) with an auto-added ``created_at``. Retrieve via
+        :func:`get_lineage`. When ``None``, no sidecar is written.
+    indent
+        Passed through to ``json.dumps``. Defaults to compact (no indent);
+        S3-served payloads usually want that.
+
+    Returns
+    -------
+    str
+        The URI written.
+    """
+    uri = str(uri)
+    data = json.dumps(obj, default=str, ensure_ascii=False, indent=indent).encode("utf-8")
+
+    opts = _b.write_target(uri)
+    with fsspec.open(uri, "wb", compression=_compression(uri), **opts) as f:
+        f.write(data)
+
+    if lineage is not None:
+        sidecar = uri + _SIDECAR_SUFFIX
+        payload = json.dumps(
+            {"created_at": datetime.now(timezone.utc).isoformat(), **lineage},
+            default=str,
+        ).encode("utf-8")
+        # sidecar is always small + raw JSON (no compression)
+        with fsspec.open(sidecar, "wb", **_b.write_target(sidecar)) as f:
+            f.write(payload)
+
+    logger.info("Wrote JSON -> %s%s", uri, " (+lineage)" if lineage is not None else "")
+    return uri
+
+
+def read_json(
+    uri: str | Path,
+    *,
+    use_cache: bool = True,
+    cache_dir: Path | None = None,
+    check_remote: bool = True,
+) -> Any:
+    """Read and parse a JSON file.
+
+    For ``s3://`` sources with ``use_cache=True`` (default), reads go through a
+    local filecache with an ETag HEAD on every open. Local paths read directly.
+
+    Parameters
+    ----------
+    uri
+        Source. Local path, ``file://`` URI, or full ``s3://`` URI. ``.gz`` is
+        decompressed transparently.
+    use_cache
+        If False, skip the local cache and read straight from S3 every time.
+    cache_dir
+        Override the default cache directory
+        (``~/.cache/vdl-tools/json``, or ``VDL_JSON_CACHE_DIR``).
+    check_remote
+        If True (default), HEAD-check the remote ETag on every open so a
+        concurrent writer's new version invalidates the local cache. Set False
+        for offline use.
+    """
+    uri = str(uri)
+    effective_uri, opts = _b.read_target(
+        uri, use_cache, cache_dir or DEFAULT_CACHE_DIR, check_remote
+    )
+    with fsspec.open(effective_uri, "rb", compression=_compression(uri), **opts) as f:
+        return json.loads(f.read())
+
+
+def get_lineage(
+    uri: str | Path,
+    *,
+    use_cache: bool = True,
+    cache_dir: Path | None = None,
+    check_remote: bool = True,
+) -> dict:
+    """Return the lineage dict from a file's sidecar (``{uri}.vdl.json``).
+
+    Returns an empty dict if the file was written without ``lineage=``. Same
+    cache semantics as :func:`read_json`.
+    """
+    sidecar = str(uri) + _SIDECAR_SUFFIX
+    effective_uri, opts = _b.read_target(
+        sidecar, use_cache, cache_dir or DEFAULT_CACHE_DIR, check_remote
+    )
+    try:
+        with fsspec.open(effective_uri, "rb", **opts) as f:
+            return json.loads(f.read())
+    except FileNotFoundError:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Public API — multi-file
+# ---------------------------------------------------------------------------
+
+def write_jsons(
+    objs: dict[str, Any],
+    dir_uri: str | Path,
+    *,
+    lineage: dict | None = None,
+    ext: str = ".json",
+) -> dict[str, str]:
+    """Write each non-None value as ``{dir_uri}/{name}{ext}``.
+
+    Parameters
+    ----------
+    objs
+        Mapping of name -> JSON-serializable value. ``None`` values are skipped.
+    dir_uri
+        Directory-like container. Local path, ``file://`` URI, or ``s3://`` URI.
+    lineage
+        Optional dict applied to every file's sidecar; ``name`` is added per file.
+    ext
+        Filename extension, e.g. ``".json"`` (default) or ``".json.gz"``.
+
+    Returns
+    -------
+    dict[str, str]
+        ``{name: uri_written}``.
+    """
+    base = str(dir_uri).rstrip("/")
+    return {
+        name: write_json(
+            obj,
+            f"{base}/{name}{ext}",
+            lineage=None if lineage is None else {**lineage, "name": name},
+        )
+        for name, obj in objs.items()
+        if obj is not None
+    }
+
+
+def read_jsons(
+    dir_uri: str | Path,
+    names: list[str],
+    *,
+    ext: str = ".json",
+    use_cache: bool = True,
+    cache_dir: Path | None = None,
+    check_remote: bool = True,
+) -> dict[str, Any]:
+    """Read ``{dir_uri}/{name}{ext}`` for each name. See :func:`read_json`."""
+    base = str(dir_uri).rstrip("/")
+    return {
+        name: read_json(
+            f"{base}/{name}{ext}",
+            use_cache=use_cache,
+            cache_dir=cache_dir,
+            check_remote=check_remote,
+        )
+        for name in names
+    }

--- a/vdl_tools/shared_tools/json_cache.py
+++ b/vdl_tools/shared_tools/json_cache.py
@@ -94,8 +94,11 @@ def write_json(
             {"created_at": datetime.now(timezone.utc).isoformat(), **lineage},
             default=str,
         ).encode("utf-8")
-        # sidecar is always small + raw JSON (no compression)
-        with fsspec.open(sidecar, "wb", **_b.write_target(sidecar)) as f:
+        # sidecar shares the data file's bucket / parent dir, so reuse ``opts``
+        # rather than re-running write_target (which would re-issue a bucket_exists
+        # HEAD, or re-create the parent, for a target already prepared above).
+        # Always small + raw JSON (no compression).
+        with fsspec.open(sidecar, "wb", **opts) as f:
             f.write(payload)
 
     logger.info("Wrote JSON -> %s%s", uri, " (+lineage)" if lineage is not None else "")

--- a/vdl_tools/shared_tools/parquet_cache.py
+++ b/vdl_tools/shared_tools/parquet_cache.py
@@ -29,65 +29,16 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from vdl_tools.shared_tools.tools.logger import logger
-from vdl_tools.shared_tools.tools.config_utils import get_configuration
-from vdl_tools.shared_tools.s3_tools import get_s3_client, create_bucket, bucket_exists
+from vdl_tools.shared_tools import _s3_cache_backend as _b
 
 
 DEFAULT_CACHE_DIR = Path(
-    os.environ.get("VDL_PARQUET_CACHE_DIR", Path.home() / ".cache" / "vdl-tools" / "parquet")
+    os.environ.get("VDL_PARQUET_CACHE_DIR", _b.DEFAULT_CACHE_ROOT / "parquet")
 )
 
 _JSON_COLS_KEY = b"vdl_json_columns"
 _LINEAGE_KEY = b"vdl_lineage"
 _SAMPLE_SIZE = 100  # non-null values per column to check when scanning
-
-
-# ---------------------------------------------------------------------------
-# URIs & S3 credentials
-# ---------------------------------------------------------------------------
-
-def _is_s3(uri: str) -> bool:
-    return uri.startswith("s3://")
-
-
-def _s3_creds() -> dict:
-    """Read AWS creds from config.ini ``[aws]``. Empty dict → boto3 default chain."""
-    try:
-        aws = get_configuration()["aws"]
-    except Exception:
-        return {}
-    opts: dict = {}
-    if aws.get("access_key_id"):
-        opts["key"] = aws["access_key_id"]
-    if aws.get("secret_access_key"):
-        opts["secret"] = aws["secret_access_key"]
-    if aws.get("region"):
-        opts["client_kwargs"] = {"region_name": aws["region"]}
-    return opts
-
-
-def _read_target(
-    uri: str,
-    use_cache: bool,
-    cache_dir: Path | None,
-    check_remote: bool,
-) -> tuple[str, dict]:
-    """Return (effective_uri, fsspec_opts) for reading from ``uri``."""
-    if not _is_s3(uri):
-        return uri, {}
-    if not use_cache:
-        return uri, {"s3": _s3_creds()}
-    cache_dir = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return f"filecache::{uri}", {
-        "filecache": {
-            "cache_storage": str(cache_dir),
-            "check_files": check_remote,  # ETag HEAD on every open
-            "expiry_time": None,          # no TTL — rely on ETag check
-            "same_names": False,
-        },
-        "s3": _s3_creds(),
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -154,10 +105,6 @@ def _decode_json(v):
 
 def _to_string(v):
     return None if _is_null(v) else str(v)
-
-
-def _is_s3_bucket_exists(uri: str) -> bool:
-    return _is_s3(uri) and bucket_exists(uri.split("/")[2])
 
 
 # ---------------------------------------------------------------------------
@@ -236,14 +183,7 @@ def write_dataframe(
     ).encode()
     table = table.replace_schema_metadata(meta)
 
-    if _is_s3(uri):
-        opts = {"s3": _s3_creds()}
-        # Check if the bucket exists and create it if it doesn't
-        if not _is_s3_bucket_exists(uri):
-            create_bucket(get_s3_client(), uri.split("/")[2])
-    else:
-        Path(uri).parent.mkdir(parents=True, exist_ok=True)
-        opts = {}
+    opts = _b.write_target(uri)
 
     with fsspec.open(uri, "wb", **opts) as f:
         pq.write_table(table, f, compression="zstd", compression_level=3)
@@ -287,7 +227,9 @@ def read_dataframe(
         validating against the remote.
     """
     uri = str(uri)
-    effective_uri, opts = _read_target(uri, use_cache, cache_dir, check_remote)
+    effective_uri, opts = _b.read_target(
+        uri, use_cache, cache_dir or DEFAULT_CACHE_DIR, check_remote
+    )
 
     with fsspec.open(effective_uri, "rb", **opts) as f:
         table = pq.read_table(f, columns=columns)
@@ -322,7 +264,9 @@ def get_lineage(
         See :func:`read_dataframe` — same cache semantics apply.
     """
     uri = str(uri)
-    effective_uri, opts = _read_target(uri, use_cache, cache_dir, check_remote)
+    effective_uri, opts = _b.read_target(
+        uri, use_cache, cache_dir or DEFAULT_CACHE_DIR, check_remote
+    )
     with fsspec.open(effective_uri, "rb", **opts) as f:
         meta = pq.ParquetFile(f).schema_arrow.metadata or {}
     return json.loads(meta.get(_LINEAGE_KEY) or b"{}")


### PR DESCRIPTION
## What

Generalizes the transparent local-caching machinery in `parquet_cache.py` so **JSON** gets the same easy local / `s3://` I/O — with remote reads cached locally and ETag-validated on every open (no silent stale reads).

Three files, **no new dependencies** (stdlib `json` + `gzip`, existing `fsspec`):

| File | What |
|---|---|
| `_s3_cache_backend.py` (new) | Shared S3 / creds / ETag-filecache / bucket-create core, extracted from `parquet_cache` so credential and caching behavior can't drift between modules. |
| `json_cache.py` (new) | `write_json` / `read_json` / `get_lineage` / `write_jsons` / `read_jsons`, mirroring the `parquet_cache` API and cache semantics (`use_cache` / `check_remote` / `cache_dir`). |
| `parquet_cache.py` (changed) | Rewired onto the shared backend. Public API and behavior unchanged. |

## Why

The valuable part of `parquet_cache` was never Parquet-specific — it's the `s3://` + local-`filecache`-with-ETag-validation plumbing. Extracting it lets JSON reuse the same "speed optimization" and gives us one code path for creds/caching instead of two that can drift.

## Design decisions for a reviewer

1. **Data files stay pure JSON.** Parquet hides lineage in the footer; JSON has none. Since our public buckets often serve JSON straight to frontends, the bytes on disk / in S3 are exactly what `json.dumps` produced. Optional `lineage` goes to a small sidecar (`{uri}.vdl.json`) written only when passed, read back via `get_lineage`; `read_json` never touches it.
2. **Compression by extension.** `…​.json` → raw (frontend-servable); `…​.json.gz` → gzipped (JSON compresses ~10×, good for internal blobs). Note: keep frontend-fetched files as `.json` — fsspec writes no `Content-Encoding` header, so browsers won't auto-decompress `.gz`.
3. **Refactored rather than duplicated.** Cache root unified under `~/.cache/vdl-tools/{parquet,json}`. `VDL_PARQUET_CACHE_DIR` is still honored; `VDL_JSON_CACHE_DIR` added.

## Testing

Local round-trip smoke test passed: raw JSON (pure bytes verified), `.json.gz` (gzip magic + lineage sidecar), multi-file `write_jsons`/`read_jsons`, and `parquet_cache` round-trip (incl. JSON columns + lineage) confirming the refactor is behavior-preserving. Verified no other modules import the private helpers that moved.

## Not included

No `prune_cache` for the JSON cache dir — `parquet_cache.prune_cache(cache_dir=...)` already works on any directory. Open to hoisting it into the shared backend if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
