### PR TITLE
Make NZI company search resumable, concurrent, and retry transient failures

### DIFF
--- a/vdl_tools/scrape_enrich/netzero_insights/netzero_api.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/netzero_api.py
@@ -1,13 +1,24 @@
 
-import os
-import requests
-import aiohttp
 import asyncio
-from typing import Dict, List, Optional, Union, Generator, Type
+import hashlib
+import json
+import math
+import os
+import random
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Type
+
+import aiohttp
+import requests
+
 from vdl_tools.shared_tools.tools.logger import logger
 from vdl_tools.scrape_enrich.netzero_insights.filters import (
     Sorting, MainFilter,
 )
+from vdl_tools.shared_tools.json_cache import read_json, write_json, target_exists
 
 from vdl_tools.shared_tools.database_cache.database_models import (
     CompanyCommercialDeal,
@@ -24,6 +35,78 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 PROD_BASE_URL = "https://api.netzeroinsights.com"
 SANDBOX_BASE_URL = "https://20.108.20.67"
 
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+AUTH_STATUS_CODES = frozenset({401, 403})
+
+DEFAULT_SEARCH_CHECKPOINT_DIR = os.environ.get(
+    "NZI_SEARCH_CHECKPOINT_DIR",
+    os.path.expanduser("~/.cache/vdl-tools/nzi_search"),
+)
+
+
+class SearchCheckpoint:
+    """Per-page checkpoint store for a paginated search.
+
+    Pages are keyed by offset under a directory derived from a hash of the
+    full search payload, so a checkpoint can never be resumed against a
+    different query. Storage goes through ``json_cache`` (local path or
+    ``s3://``).
+    """
+
+    def __init__(self, base_dir: str, endpoint: str, payload: Dict, page_size: int):
+        self.payload = payload
+        self.page_size = page_size
+        self.endpoint = endpoint
+        key_material = json.dumps(
+            {"endpoint": endpoint, "payload": payload, "page_size": page_size},
+            sort_keys=True,
+            default=str,
+        )
+        self.search_key = hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:16]
+        self.base_uri = f"{str(base_dir).rstrip('/')}/{self.search_key}"
+
+    def _page_uri(self, offset: int) -> str:
+        return f"{self.base_uri}/page_{offset:09d}.json.gz"
+
+    @property
+    def _meta_uri(self) -> str:
+        return f"{self.base_uri}/meta.json"
+
+    def load_meta(self, max_age: timedelta) -> Optional[Dict]:
+        """Return the checkpoint metadata, or None if absent or older than max_age."""
+        if not target_exists(self._meta_uri):
+            return None
+        meta = read_json(self._meta_uri)
+        created_at = datetime.fromisoformat(meta["created_at"])
+        if datetime.now(timezone.utc) - created_at > max_age:
+            logger.info(
+                "Search checkpoint %s is older than %s — refetching all pages",
+                self.base_uri, max_age,
+            )
+            return None
+        return meta
+
+    def write_meta(self, total_count: int) -> None:
+        write_json(
+            {
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "endpoint": self.endpoint,
+                "payload": self.payload,
+                "page_size": self.page_size,
+                "total_count": total_count,
+            },
+            self._meta_uri,
+        )
+
+    def has_page(self, offset: int) -> bool:
+        return target_exists(self._page_uri(offset))
+
+    def read_page(self, offset: int) -> Dict:
+        return read_json(self._page_uri(offset))
+
+    def write_page(self, offset: int, page: Dict) -> None:
+        write_json(page, self._page_uri(offset))
+
 
 class NetZeroAPI:
     """Client for interacting with the NetZero Insights API."""
@@ -34,7 +117,8 @@ class NetZeroAPI:
         password: str,
         use_sandbox: bool = False,
         read_from_cache: bool = True,
-        write_to_cache: bool = True
+        write_to_cache: bool = True,
+        max_concurrent_requests: int = 10,
     ):
         """Initialize the API client with credentials.
 
@@ -42,6 +126,10 @@ class NetZeroAPI:
             username: NetZero Insights API username
             password: NetZero Insights API password
             use_sandbox: Whether to use the sandbox environment
+            max_concurrent_requests: Cap on simultaneous requests per detail
+                batch. Note that stages fetched in parallel (e.g. startup
+                details + funding rounds) each get their own cap, so peak
+                concurrency against the API can be a small multiple of this.
         """
         logger.info(f"Initializing NetZero API client with {'sandbox' if use_sandbox else 'production'} environment")
         self.username = username
@@ -51,10 +139,13 @@ class NetZeroAPI:
         self.read_from_cache = read_from_cache
         self.write_to_cache = write_to_cache
         self.use_sandbox = use_sandbox
+        self.max_concurrent_requests = max_concurrent_requests
         # The production ssl certifcate seems to expired too
         self.verify_ssl = not use_sandbox
         # self.verify_ssl = False
 
+        self._auth_lock = threading.Lock()
+        self._auth_generation = 0
         self._authenticate()
 
     def _authenticate(self) -> None:
@@ -87,6 +178,69 @@ class NetZeroAPI:
             logger.error(f"Failed to logout from NetZero API: {str(e)}")
             raise
 
+    def _reauthenticate(self, seen_generation: int) -> int:
+        """Re-login after an auth failure, at most once per expiry.
+
+        Many threads/tasks can hit a 401 from the same expired cookie at the
+        same time; the generation counter makes only the first one actually
+        re-login, the rest just pick up the fresh session.
+        """
+        with self._auth_lock:
+            if self._auth_generation == seen_generation:
+                self._authenticate()
+                self._auth_generation += 1
+            return self._auth_generation
+
+    def _request_with_retries(
+        self,
+        method: str,
+        endpoint: str,
+        max_retries: int = 4,
+        **kwargs,
+    ) -> Dict:
+        """Issue a request, retrying transient failures and refreshing auth.
+
+        Retries 429/5xx and connection errors with exponential backoff +
+        jitter. A 401/403 triggers a single re-authentication (the session
+        cookie expires on long runs) before retrying.
+        """
+        url = os.path.join(self.base_url, endpoint)
+        reauthed = False
+        response = None
+        for attempt in range(max_retries):
+            auth_generation = self._auth_generation
+            try:
+                response = self.session.request(
+                    method, url, verify=self.verify_ssl, **kwargs,
+                )
+            except requests.exceptions.RequestException as e:
+                if attempt == max_retries - 1:
+                    logger.error(f"Request to {endpoint} failed after {max_retries} attempts: {e}")
+                    raise
+                wait = 2 ** attempt + random.random()
+                logger.warning(f"Request to {endpoint} failed ({e}), retrying in {wait:.1f}s")
+                time.sleep(wait)
+                continue
+
+            if response.status_code in AUTH_STATUS_CODES and not reauthed:
+                logger.warning(f"HTTP {response.status_code} from {endpoint} — re-authenticating")
+                self._reauthenticate(auth_generation)
+                reauthed = True
+                continue
+
+            if response.status_code in RETRYABLE_STATUS_CODES and attempt < max_retries - 1:
+                wait = 2 ** attempt + random.random()
+                logger.warning(f"HTTP {response.status_code} from {endpoint}, retrying in {wait:.1f}s")
+                time.sleep(wait)
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+        # Only reachable if the final attempt was spent on a re-auth retry
+        response.raise_for_status()
+        return response.json()
+
     def _get(
         self,
         endpoint: str,
@@ -94,14 +248,7 @@ class NetZeroAPI:
         headers: Dict = None
     ) -> Dict:
         """Get a resource from the API."""
-        response = self.session.get(
-            os.path.join(self.base_url, endpoint),
-            params=params,
-            verify=self.verify_ssl,
-            headers=headers,
-        )
-        response.raise_for_status()
-        return response.json()
+        return self._request_with_retries("GET", endpoint, params=params, headers=headers)
 
     def _post(
         self,
@@ -110,78 +257,7 @@ class NetZeroAPI:
         headers: Dict = None
     ) -> Dict:
         """Post a resource to the API."""
-        response = self.session.post(
-            os.path.join(self.base_url, endpoint),
-            json=payload,
-            verify=self.verify_ssl,
-            headers=headers,
-        )
-        response.raise_for_status()
-        return response.json()
-
-    def _paginate(
-        self,
-        endpoint: str,
-        payload: Dict,
-        page_size: int = 100,
-        max_pages: Optional[int] = None
-    ) -> Generator[Dict, None, None]:
-        """Helper method to handle pagination for list endpoints.
-
-        Args:
-            endpoint: The API endpoint to call
-            payload: The base payload for the request
-            page_size: Number of items per page
-            max_pages: Maximum number of pages to fetch (None for all pages)
-        Yields:
-            Dict containing the results for each page
-        """
-        offset = 0
-        page = 1
-        total_count = None
-
-        while True:
-            if max_pages and page > max_pages:
-                logger.info(f"Reached maximum page limit of {max_pages}")
-                break
-
-            # Update payload with current pagination parameters
-            current_payload = payload.copy()
-            current_payload.update({
-                "limit": page_size,
-                "offset": offset
-            })
-
-            try:
-                data = self._post(
-                    endpoint=endpoint,
-                    payload=current_payload,
-                    headers={"Content-Type": "application/json"},
-                )
-                # Get total count on first page
-                if total_count is None:
-                    total_count = data.get("count", 0)
-                    logger.info(f"Total items available: {total_count}")
-
-                results = data.get("results", [])
-                if not results:
-                    logger.info("No more results available")
-                    break
-
-                logger.info(f"Fetched page {page} with {len(results)} items")
-                yield data
-
-                # Check if we've reached the end
-                if offset + page_size >= total_count:
-                    logger.info("Reached end of results")
-                    break
-
-                offset += page_size
-                page += 1
-
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Failed to fetch page {page}: {str(e)}")
-                raise
+        return self._request_with_retries("POST", endpoint, json=payload, headers=headers)
 
     def _resolve_cache_params(
         self,
@@ -197,23 +273,37 @@ class NetZeroAPI:
     def _search_entities(
         self,
         endpoint: str,
-        filter: Optional[Union[MainFilter]] = None,
+        filter: Optional[MainFilter] = None,
         sorting: Optional[Sorting] = None,
         limit: Optional[int] = None,
         offset: int = 0,
         page_size: int = 100,
-        max_pages: Optional[int] = None
+        max_pages: Optional[int] = None,
+        checkpoint_dir: Optional[str] = None,
+        checkpoint_max_age_days: float = 7.0,
+        max_concurrent_pages: int = 8,
+        unique_key: Optional[str] = None,
     ) -> Dict:
         """Base method for searching entities.
 
         Args:
             endpoint: The API endpoint to call (e.g., 'companies', 'fundingRounds', 'investors')
             filter: Filter criteria for the entities
-            sorting: Sorting criteria
+            sorting: Sorting criteria. Strongly recommended when checkpointing
+                or fetching pages concurrently — without a stable order the API
+                may shift rows between pages.
             limit: Maximum number of results to return (None for all results)
             offset: Number of results to skip
             page_size: Number of items per page when using pagination
             max_pages: Maximum number of pages to fetch (None for all pages)
+            checkpoint_dir: If set, each fetched page is persisted under
+                ``{checkpoint_dir}/{hash(query)}/`` and a re-run of the same
+                query resumes from the pages already on disk / S3.
+            checkpoint_max_age_days: Checkpoints older than this are refetched.
+            max_concurrent_pages: Number of pages fetched in parallel.
+            unique_key: Field name used to drop duplicate results across pages
+                (e.g. ``clientID``); duplicates can appear when the underlying
+                data shifts between page fetches.
 
         Returns:
             Dict containing:
@@ -223,60 +313,127 @@ class NetZeroAPI:
         """
         logger.info(f"Fetching {endpoint} with offset={offset}")
 
-        # Handle different filter types
-        if isinstance(filter, MainFilter):
-            payload = filter.model_dump()
-            if sorting:
-                payload["sorting"] = sorting.model_dump()
+        filter = filter or MainFilter()
+        payload = filter.model_dump()
+        if sorting:
+            payload["sorting"] = sorting.model_dump()
+        # limit/offset are set per page request
+        payload.pop("limit", None)
+        payload.pop("offset", None)
 
-        if limit is not None and limit < 100:
-            # Single request with limit
-            payload.update({
-                "limit": limit,
-                "offset": offset
-            })
-            try:
-                data = self._post(
-                    endpoint=endpoint,
-                    payload=payload,
-                    headers={"Content-Type": "application/json"},
-                )
-                logger.info(f"Successfully fetched {len(data.get('results', []))} `{endpoint}`")
-                return {
-                    "total_count": data.get("count", 0),
-                    "count": len(data.get("results", [])),
-                    "results": data.get("results", [])
-                }
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Failed to fetch `{endpoint}`: {str(e)}")
-                raise
-        else:
-            if limit is not None:
-                max_pages = limit // page_size
-            # Paginated requests
-            paginated_results = self._paginate(
+        if limit is not None and limit <= page_size:
+            # Small enough for a single request — no pagination or checkpoint needed
+            data = self._post(
                 endpoint=endpoint,
-                payload=payload,
-                page_size=page_size,
-                max_pages=max_pages
+                payload={**payload, "limit": limit, "offset": offset},
+                headers={"Content-Type": "application/json"},
             )
-
-            count_in_result = 0
-            results = []
-            total_count = None
-
-            for page in paginated_results:
-                if total_count is None:
-                    total_count = page.get("count", 0)
-                page_results = page.get("results", [])
-                results.extend(page_results)
-                count_in_result += len(page_results)
-
+            results = data.get("results", [])
+            logger.info(f"Successfully fetched {len(results)} `{endpoint}`")
             return {
-                "total_count": total_count,
-                "count": count_in_result,
-                "results": results
+                "total_count": data.get("count", 0),
+                "count": len(results),
+                "results": results,
             }
+
+        checkpoint = None
+        meta = None
+        if checkpoint_dir:
+            if sorting is None:
+                logger.warning(
+                    "Checkpointed search without explicit sorting — if the "
+                    "underlying data changes between runs, resumed pages may "
+                    "contain duplicates or miss rows."
+                )
+            checkpoint = SearchCheckpoint(checkpoint_dir, endpoint, payload, page_size)
+            meta = checkpoint.load_meta(timedelta(days=checkpoint_max_age_days))
+            if meta:
+                logger.info(f"Resuming search from checkpoint {checkpoint.base_uri}")
+
+        def fetch_page(page_offset: int, allow_cached: bool) -> Dict:
+            if allow_cached and checkpoint and checkpoint.has_page(page_offset):
+                return checkpoint.read_page(page_offset)
+            data = self._post(
+                endpoint=endpoint,
+                payload={**payload, "limit": page_size, "offset": page_offset},
+                headers={"Content-Type": "application/json"},
+            )
+            page = {"count": data.get("count", 0), "results": data.get("results", [])}
+            if checkpoint:
+                checkpoint.write_page(page_offset, page)
+            return page
+
+        # Only trust existing page files when resuming a fresh checkpoint —
+        # otherwise stale pages from an expired run would be read back
+        resuming = meta is not None
+
+        # First page establishes total_count (from checkpoint meta when resuming)
+        first_page = fetch_page(offset, allow_cached=resuming)
+        total_count = meta["total_count"] if resuming else first_page["count"]
+        if checkpoint and not resuming:
+            checkpoint.write_meta(total_count)
+
+        available = max(total_count - offset, 0)
+        target = available if limit is None else min(limit, available)
+        n_pages = math.ceil(target / page_size) if target else 1
+        if max_pages is not None and n_pages > max_pages:
+            logger.info(f"Capping fetch at max_pages={max_pages}")
+            n_pages = max_pages
+
+        pages = {offset: first_page}
+        remaining_offsets = [offset + i * page_size for i in range(1, n_pages)]
+        if remaining_offsets:
+            logger.info(
+                f"Fetching {len(remaining_offsets)} more pages of `{endpoint}` "
+                f"({max_concurrent_pages} concurrent)"
+            )
+            with ThreadPoolExecutor(max_workers=max_concurrent_pages) as executor:
+                futures = {
+                    executor.submit(fetch_page, page_offset, resuming): page_offset
+                    for page_offset in remaining_offsets
+                }
+                try:
+                    for done, future in enumerate(as_completed(futures), start=2):
+                        pages[futures[future]] = future.result()
+                        if done % 25 == 0:
+                            logger.info(f"Fetched {done}/{n_pages} pages of `{endpoint}`")
+                except Exception:
+                    # Completed pages are already checkpointed; a re-run resumes
+                    executor.shutdown(cancel_futures=True)
+                    raise
+
+        results = []
+        for page_offset in sorted(pages):
+            page_results = pages[page_offset].get("results", [])
+            if not page_results:
+                break
+            results.extend(page_results)
+
+        if unique_key:
+            seen = set()
+            deduped = []
+            for result in results:
+                key = result.get(unique_key)
+                if key is not None and key in seen:
+                    continue
+                seen.add(key)
+                deduped.append(result)
+            if len(deduped) < len(results):
+                logger.warning(
+                    f"Dropped {len(results) - len(deduped)} duplicate "
+                    f"`{endpoint}` results by {unique_key}"
+                )
+            results = deduped
+
+        if limit is not None:
+            results = results[:limit]
+
+        logger.info(f"Fetched {len(results)} `{endpoint}` (total available: {total_count})")
+        return {
+            "total_count": total_count,
+            "count": len(results),
+            "results": results,
+        }
 
     def get_startup_count(self, main_filter: MainFilter = None) -> int:
         """Get the total number of startups matching the specified criteria."""
@@ -293,8 +450,11 @@ class NetZeroAPI:
         limit: Optional[int] = None,
         offset: int = 0,
         page_size: int = 100,
-        max_pages: Optional[int] = None
-    ) -> Union[Dict, Generator[Dict, None, None]]:
+        max_pages: Optional[int] = None,
+        checkpoint_dir: Optional[str] = None,
+        checkpoint_max_age_days: float = 7.0,
+        max_concurrent_pages: int = 8,
+    ) -> Dict:
         """Get a list of startups matching the specified criteria."""
         return self._search_entities(
             endpoint="companies",
@@ -303,7 +463,11 @@ class NetZeroAPI:
             limit=limit,
             offset=offset,
             page_size=page_size,
-            max_pages=max_pages
+            max_pages=max_pages,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_max_age_days=checkpoint_max_age_days,
+            max_concurrent_pages=max_concurrent_pages,
+            unique_key="clientID",
         )
 
     def search_deals(
@@ -313,8 +477,11 @@ class NetZeroAPI:
         limit: Optional[int] = None,
         offset: int = 0,
         page_size: int = 100,
-        max_pages: Optional[int] = None
-    ) -> Union[Dict, Generator[Dict, None, None]]:
+        max_pages: Optional[int] = None,
+        checkpoint_dir: Optional[str] = None,
+        checkpoint_max_age_days: float = 7.0,
+        max_concurrent_pages: int = 8,
+    ) -> Dict:
         """Get a list of deals matching the specified criteria."""
         return self._search_entities(
             endpoint="fundingRounds",
@@ -323,7 +490,10 @@ class NetZeroAPI:
             limit=limit,
             offset=offset,
             page_size=page_size,
-            max_pages=max_pages
+            max_pages=max_pages,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_max_age_days=checkpoint_max_age_days,
+            max_concurrent_pages=max_concurrent_pages,
         )
 
     def search_investors(
@@ -333,8 +503,11 @@ class NetZeroAPI:
         limit: Optional[int] = None,
         offset: int = 0,
         page_size: int = 100,
-        max_pages: Optional[int] = None
-    ) -> Union[Dict, Generator[Dict, None, None]]:
+        max_pages: Optional[int] = None,
+        checkpoint_dir: Optional[str] = None,
+        checkpoint_max_age_days: float = 7.0,
+        max_concurrent_pages: int = 8,
+    ) -> Dict:
         """Get a list of investors matching the specified criteria."""
         return self._search_entities(
             endpoint="investors",
@@ -343,7 +516,11 @@ class NetZeroAPI:
             limit=limit,
             offset=offset,
             page_size=page_size,
-            max_pages=max_pages
+            max_pages=max_pages,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_max_age_days=checkpoint_max_age_days,
+            max_concurrent_pages=max_concurrent_pages,
+            unique_key="investorID",
         )
 
     async def _get_details_batch(
@@ -388,25 +565,47 @@ class NetZeroAPI:
         if not missing_ids:
             return [results[id] for id in ids]
 
-        cookies = self.session.cookies.get_dict()
-        if not cookies:
+        auth_state = {
+            "cookies": self.session.cookies.get_dict(),
+            "generation": self._auth_generation,
+        }
+        if not auth_state["cookies"]:
             logger.warning("No session cookies found — requests may fail auth")
         request_timeout = aiohttp.ClientTimeout(total=90)
         max_retries = 3
-        max_concurrent = 10
-        semaphore = asyncio.Semaphore(max_concurrent)
+        semaphore = asyncio.Semaphore(self.max_concurrent_requests)
 
         async def fetch_entity(session: aiohttp.ClientSession, id: int) -> Dict:
             async with semaphore:
+                reauthed = False
                 for attempt in range(max_retries):
                     try:
                         async with session.get(
                             f"{self.base_url}/{endpoint.rstrip('/')}/{id}",
-                            cookies=cookies,
+                            cookies=auth_state["cookies"],
                             headers={"Accept": "application/json, text/plain, */*"},
                             timeout=request_timeout,
                             ssl=self.verify_ssl,
                         ) as response:
+                            if response.status in AUTH_STATUS_CODES and not reauthed:
+                                # Session cookie likely expired mid-run; refresh
+                                # once (generation-guarded, so concurrent tasks
+                                # trigger a single re-login) and retry
+                                logger.warning(f"HTTP {response.status} for {endpoint} {id} — re-authenticating")
+                                auth_state["generation"] = await asyncio.to_thread(
+                                    self._reauthenticate, auth_state["generation"]
+                                )
+                                auth_state["cookies"] = self.session.cookies.get_dict()
+                                reauthed = True
+                                continue
+                            if response.status in RETRYABLE_STATUS_CODES and attempt < max_retries - 1:
+                                wait = 2 ** attempt + random.random()
+                                logger.warning(
+                                    f"HTTP {response.status} for {endpoint} {id} "
+                                    f"(attempt {attempt + 1}/{max_retries}), retrying in {wait:.1f}s"
+                                )
+                                await asyncio.sleep(wait)
+                                continue
                             if response.status >= 400:
                                 body = (await response.text())[:500]
                                 logger.error(f"Failed {endpoint} {id}: HTTP {response.status} | {body!r}")
@@ -422,12 +621,15 @@ class NetZeroAPI:
                             args[primary_key_field] = id
                             args["fullData"] = data
                             return id, args
-                    except (TimeoutError, asyncio.TimeoutError):
+                    except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError) as e:
                         if attempt < max_retries - 1:
-                            logger.warning(f"Timeout {endpoint} {id} (attempt {attempt + 1}/{max_retries}), retrying...")
-                            await asyncio.sleep(2 ** attempt)
+                            logger.warning(
+                                f"{type(e).__name__} {endpoint} {id} "
+                                f"(attempt {attempt + 1}/{max_retries}), retrying..."
+                            )
+                            await asyncio.sleep(2 ** attempt + random.random())
                         else:
-                            logger.error(f"Failed {endpoint} {id}: timeout after {max_retries} attempts")
+                            logger.error(f"Failed {endpoint} {id}: {type(e).__name__} after {max_retries} attempts")
                             return id, None
                     except Exception as e:
                         logger.error(f"Failed {endpoint} {id}: {type(e).__name__}: {e}")

--- a/vdl_tools/scrape_enrich/netzero_insights/netzero_api.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/netzero_api.py
@@ -74,9 +74,10 @@ class SearchCheckpoint:
 
     def load_meta(self, max_age: timedelta) -> Optional[Dict]:
         """Return the checkpoint metadata, or None if absent or older than max_age."""
-        if not target_exists(self._meta_uri):
+        try:
+            meta = read_json(self._meta_uri)
+        except FileNotFoundError:
             return None
-        meta = read_json(self._meta_uri)
         created_at = datetime.fromisoformat(meta["created_at"])
         if datetime.now(timezone.utc) - created_at > max_age:
             logger.info(
@@ -207,7 +208,8 @@ class NetZeroAPI:
         url = os.path.join(self.base_url, endpoint)
         reauthed = False
         response = None
-        for attempt in range(max_retries):
+        attempt = 0
+        while attempt < max_retries:
             auth_generation = self._auth_generation
             try:
                 response = self.session.request(
@@ -220,24 +222,29 @@ class NetZeroAPI:
                 wait = 2 ** attempt + random.random()
                 logger.warning(f"Request to {endpoint} failed ({e}), retrying in {wait:.1f}s")
                 time.sleep(wait)
+                attempt += 1
                 continue
 
             if response.status_code in AUTH_STATUS_CODES and not reauthed:
                 logger.warning(f"HTTP {response.status_code} from {endpoint} — re-authenticating")
                 self._reauthenticate(auth_generation)
                 reauthed = True
+                # A re-auth doesn't consume a retry slot — otherwise a 401 on the
+                # final attempt would refresh the session and then raise without
+                # ever retrying with the fresh cookie.
                 continue
 
             if response.status_code in RETRYABLE_STATUS_CODES and attempt < max_retries - 1:
                 wait = 2 ** attempt + random.random()
                 logger.warning(f"HTTP {response.status_code} from {endpoint}, retrying in {wait:.1f}s")
                 time.sleep(wait)
+                attempt += 1
                 continue
 
             response.raise_for_status()
             return response.json()
 
-        # Only reachable if the final attempt was spent on a re-auth retry
+        # Reached only if the retry budget is exhausted; surface the last response.
         response.raise_for_status()
         return response.json()
 
@@ -351,8 +358,14 @@ class NetZeroAPI:
                 logger.info(f"Resuming search from checkpoint {checkpoint.base_uri}")
 
         def fetch_page(page_offset: int, allow_cached: bool) -> Dict:
-            if allow_cached and checkpoint and checkpoint.has_page(page_offset):
-                return checkpoint.read_page(page_offset)
+            if allow_cached and checkpoint:
+                # Read straight through instead of has_page()+read_page(): the
+                # existence probe is a redundant stat/HEAD (2 extra S3 round trips
+                # per page on resume) that the read itself already performs.
+                try:
+                    return checkpoint.read_page(page_offset)
+                except FileNotFoundError:
+                    pass
             data = self._post(
                 endpoint=endpoint,
                 payload={**payload, "limit": page_size, "offset": page_offset},
@@ -404,10 +417,10 @@ class NetZeroAPI:
 
         results = []
         for page_offset in sorted(pages):
-            page_results = pages[page_offset].get("results", [])
-            if not page_results:
-                break
-            results.extend(page_results)
+            # Don't break on an empty page: with concurrent fetches an interior
+            # page can come back empty (transient/shifted data) while later
+            # offsets returned valid rows — breaking here would silently drop them.
+            results.extend(pages[page_offset].get("results", []))
 
         if unique_key:
             seen = set()
@@ -579,6 +592,11 @@ class NetZeroAPI:
             async with semaphore:
                 reauthed = False
                 for attempt in range(max_retries):
+                    # Snapshot the auth generation *before* the request so the
+                    # generation guard works: if a peer coroutine re-logins
+                    # while this request is in flight, our seen generation is
+                    # now stale and _reauthenticate skips a redundant re-login.
+                    seen_generation = auth_state["generation"]
                     try:
                         async with session.get(
                             f"{self.base_url}/{endpoint.rstrip('/')}/{id}",
@@ -593,7 +611,7 @@ class NetZeroAPI:
                                 # trigger a single re-login) and retry
                                 logger.warning(f"HTTP {response.status} for {endpoint} {id} — re-authenticating")
                                 auth_state["generation"] = await asyncio.to_thread(
-                                    self._reauthenticate, auth_state["generation"]
+                                    self._reauthenticate, seen_generation
                                 )
                                 auth_state["cookies"] = self.session.cookies.get_dict()
                                 reauthed = True

--- a/vdl_tools/scrape_enrich/netzero_insights/search_netzero_api.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/search_netzero_api.py
@@ -4,8 +4,11 @@ import asyncio
 import pandas as pd
 
 from vdl_tools.shared_tools.tools.config_utils import get_configuration
-from vdl_tools.scrape_enrich.netzero_insights.netzero_api import NetZeroAPI
-from vdl_tools.scrape_enrich.netzero_insights.filters import MainFilter, StartupFilter, InvestorFilter
+from vdl_tools.scrape_enrich.netzero_insights.netzero_api import (
+    DEFAULT_SEARCH_CHECKPOINT_DIR,
+    NetZeroAPI,
+)
+from vdl_tools.scrape_enrich.netzero_insights.filters import MainFilter, StartupFilter, InvestorFilter, Sorting
 from vdl_tools.shared_tools.tools.logger import logger
 from vdl_tools.shared_tools.json_cache import write_json
 
@@ -142,14 +145,29 @@ def search_companies(
     limit: int = 100,
     use_sandbox: bool = False,
     netzero_api: NetZeroAPI = None,
+    sorting: Sorting = None,
+    checkpoint_dir: str = DEFAULT_SEARCH_CHECKPOINT_DIR,
+    checkpoint_max_age_days: float = 7.0,
+    max_concurrent_pages: int = 8,
     **filter_kwargs,
 ):
+    """Search NetZero Insights companies matching the given filters.
+
+    Pages are fetched concurrently and, by default, checkpointed under
+    ``checkpoint_dir`` keyed by a hash of the query — if the process dies
+    mid-search, re-running the same call resumes from the completed pages.
+    Pass ``checkpoint_dir=None`` to disable checkpointing.
+    """
     netzero_api = netzero_api or get_netzero_api(use_sandbox=use_sandbox)
     main_filter = create_search_filter(**filter_kwargs)
 
     companies = netzero_api.search_startups(
         main_filter=main_filter,
         limit=limit,
+        sorting=sorting,
+        checkpoint_dir=checkpoint_dir,
+        checkpoint_max_age_days=checkpoint_max_age_days,
+        max_concurrent_pages=max_concurrent_pages,
     )
 
     return companies
@@ -235,55 +253,46 @@ def get_full_details_from_company_ids(
         read_from_cache=read_from_cache,
         write_to_cache=write_to_cache,
     )
-    companies = get_companies_details(
-        company_ids=company_ids,
-        use_sandbox=use_sandbox,
-        read_from_cache=read_from_cache,
-        write_to_cache=write_to_cache,
-        netzero_api=netzero_api,
-    )
 
-    return_data = {
-        "companies": pd.DataFrame(companies),
-    }
     if return_investor_details and not return_funding_rounds:
         logger.warning("return_investor_details is True but return_funding_rounds is False")
-        return return_data
 
-    if return_funding_rounds:
-        funding_rounds = get_company_funding_rounds(
-            company_ids=company_ids,
-            use_sandbox=use_sandbox,
-            read_from_cache=read_from_cache,
-            write_to_cache=write_to_cache,
-            netzero_api=netzero_api,
-        )
-        funding_df = pd.DataFrame(funding_rounds)
-        return_data["funding_rounds"] = funding_df
+    async def _fetch_all():
+        # Companies, funding rounds and commercial deals only depend on
+        # company_ids, so they run concurrently; investors need the funding
+        # rounds first
+        cache_kwargs = {
+            "read_from_cache": read_from_cache,
+            "write_to_cache": write_to_cache,
+        }
+        stages = {
+            "companies": netzero_api.get_startup_details(company_ids, **cache_kwargs),
+        }
+        if return_funding_rounds:
+            stages["funding_rounds"] = netzero_api.get_company_funding_rounds(
+                company_ids, flatten=True, **cache_kwargs,
+            )
+        if get_commercial_deals:
+            stages["commercial_deals"] = netzero_api.get_company_commercial_deals(
+                company_ids, flatten=True, **cache_kwargs,
+            )
+        stage_results = await asyncio.gather(*stages.values())
+        fetched = dict(zip(stages.keys(), stage_results))
 
-    if return_investor_details:
-        investor_ids = set(
-            investor_id for investor_list in funding_df['roundInvestorIDs']
-            for investor_id in investor_list
-        )
-        investor_details = get_investor_details(
-            investor_ids=list(investor_ids),
-            use_sandbox=use_sandbox,
-            read_from_cache=read_from_cache,
-            write_to_cache=write_to_cache,
-            netzero_api=netzero_api,
-        )
-        return_data["investor_details"] = pd.DataFrame(investor_details)
+        if return_investor_details and return_funding_rounds:
+            investor_ids = sorted({
+                investor_id
+                for funding_round in fetched["funding_rounds"]
+                for investor_id in (funding_round.get("roundInvestorIDs") or [])
+            })
+            fetched["investor_details"] = await netzero_api.get_investor_details(
+                investor_ids, flatten=True, **cache_kwargs,
+            )
+        return fetched
 
-    if get_commercial_deals:
-        commercial_deals = get_company_commercial_deals(
-            company_ids=company_ids,
-            use_sandbox=use_sandbox,
-            read_from_cache=read_from_cache,
-            write_to_cache=write_to_cache,
-            netzero_api=netzero_api,
-        )
-        return_data["commercial_deals"] = pd.DataFrame(commercial_deals)
+    fetched = asyncio.run(_fetch_all())
+
+    return_data = {key: pd.DataFrame(value) for key, value in fetched.items()}
 
     if save_path:
         logger.info(f"Saving data to {save_path}")
@@ -356,7 +365,9 @@ def get_investor_details(
 if __name__ == "__main__":
     USE_SANDBOX = True
     READ_FROM_CACHE = True
-    WRITE_TO_CACHE = False
+    # Keep write_to_cache on for long runs — the DB cache is what lets a
+    # killed details fetch resume without refetching
+    WRITE_TO_CACHE = True
 
     # ocean_search = search_get_companies_details(
     #     include_keywords=["ocean"],

--- a/vdl_tools/scrape_enrich/netzero_insights/tests/test_netzero_api.py
+++ b/vdl_tools/scrape_enrich/netzero_insights/tests/test_netzero_api.py
@@ -1,10 +1,15 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
-import aiohttp
 import requests
+
 from vdl_tools.scrape_enrich.netzero_insights.netzero_api import NetZeroAPI
 from vdl_tools.scrape_enrich.netzero_insights.filters import MainFilter, Sorting
 from vdl_tools.shared_tools.database_cache.database_models import Startup
+
 
 @pytest.fixture
 def mock_session():
@@ -12,6 +17,7 @@ def mock_session():
         session = Mock()
         mock.return_value = session
         yield session
+
 
 @pytest.fixture
 def netzero_api(mock_session):
@@ -21,16 +27,41 @@ def netzero_api(mock_session):
         use_sandbox=True
     )
 
+
+def _response(payload=None, status=200):
+    resp = Mock()
+    resp.status_code = status
+    resp.json.return_value = payload
+    if status >= 400:
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(f"HTTP {status}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _search_responder(total, key="clientID", dataset=None):
+    """Fake `session.request` that serves offset/limit slices of a dataset."""
+    dataset = dataset if dataset is not None else [{key: i} for i in range(total)]
+
+    def responder(method, url, **kwargs):
+        payload = kwargs.get("json") or {}
+        offset = payload.get("offset", 0)
+        limit = payload.get("limit", 100)
+        return _response({"count": total, "results": dataset[offset:offset + limit]})
+
+    return responder
+
+
 def test_initialization(netzero_api, mock_session):
     assert netzero_api.username == "test_user"
     assert netzero_api.password == "test_pass"
     assert netzero_api.base_url == "https://20.108.20.67"
     assert netzero_api.session == mock_session
 
+
 def test_authentication_success(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.raise_for_status.return_value = None
-    mock_session.post.return_value = mock_response
+    mock_session.post.reset_mock()
+    mock_session.post.return_value = _response()
 
     netzero_api._authenticate()
 
@@ -38,128 +69,302 @@ def test_authentication_success(netzero_api, mock_session):
         "https://20.108.20.67/security/formLogin",
         data={"username": "test_user", "password": "test_pass"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
-        verify=True
+        verify=False,
     )
 
+
 def test_authentication_failure(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.raise_for_status.side_effect = requests.exceptions.RequestException("Auth failed")
-    mock_session.post.return_value = mock_response
+    mock_session.post.return_value = _response(status=401)
 
     with pytest.raises(requests.exceptions.RequestException):
         netzero_api._authenticate()
 
+
 def test_logout_success(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.raise_for_status.return_value = None
-    mock_session.get.return_value = mock_response
+    mock_session.get.return_value = _response()
 
     netzero_api.logout()
 
-    mock_session.get.assert_called_once_with("https://20.108.20.67/security/logout")
+    mock_session.get.assert_called_once_with(
+        "https://20.108.20.67/security/logout",
+        verify=False,
+    )
 
-def test_pagination(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.json.return_value = {
-        "count": 3,
-        "results": [{"id": 1}, {"id": 2}, {"id": 3}]
-    }
-    mock_response.raise_for_status.return_value = None
-    mock_session.post.return_value = mock_response
 
-    results = list(netzero_api._paginate(
-        endpoint="test",
-        payload={},
-        page_size=100
-    ))
-
-    assert len(results) == 1
-    assert results[0]["count"] == 3
-    assert len(results[0]["results"]) == 3
-
-def test_search_entities(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.json.return_value = {
-        "count": 2,
-        "results": [{"id": 1}, {"id": 2}]
-    }
-    mock_response.raise_for_status.return_value = None
-    mock_session.post.return_value = mock_response
+def test_search_entities_single_request(netzero_api, mock_session):
+    mock_session.request.side_effect = _search_responder(total=2)
 
     result = netzero_api._search_entities(
         endpoint="companies",
         filter=MainFilter(),
-        limit=2
+        limit=2,
     )
 
     assert result["total_count"] == 2
     assert result["count"] == 2
     assert len(result["results"]) == 2
+    # limit <= page_size goes out as one request
+    assert mock_session.request.call_count == 1
 
-@pytest.mark.asyncio
-async def test_get_details_batch(netzero_api, mock_session):
-    # Mock database session
-    with patch('vdl_tools.shared_tools.database_cache.database_utils.get_session') as mock_get_session:
-        mock_db_session = Mock()
-        mock_get_session.return_value.__enter__.return_value = mock_db_session
-        mock_db_session.query.return_value.filter.return_value.all.return_value = []
 
-        # Mock aiohttp session
-        mock_aiohttp_session = AsyncMock()
-        mock_aiohttp_session.get.return_value.__aenter__.return_value.json = AsyncMock(
-            return_value={"id": 1, "name": "Test Startup"}
+def test_search_entities_no_filter(netzero_api, mock_session):
+    mock_session.request.side_effect = _search_responder(total=1)
+
+    result = netzero_api._search_entities(endpoint="companies", limit=1)
+
+    assert result["count"] == 1
+
+
+def test_search_entities_limit_not_truncated_to_page_multiple(netzero_api, mock_session):
+    # limit=250 previously returned only 200 results (limit // page_size pages)
+    mock_session.request.side_effect = _search_responder(total=400)
+
+    result = netzero_api._search_entities(
+        endpoint="companies",
+        filter=MainFilter(),
+        limit=250,
+        page_size=100,
+    )
+
+    assert result["total_count"] == 400
+    assert result["count"] == 250
+    assert [r["clientID"] for r in result["results"]] == list(range(250))
+    assert mock_session.request.call_count == 3
+
+
+def test_search_entities_fetches_all_pages_concurrently(netzero_api, mock_session):
+    mock_session.request.side_effect = _search_responder(total=250)
+
+    result = netzero_api._search_entities(
+        endpoint="companies",
+        filter=MainFilter(),
+        limit=None,
+        page_size=100,
+    )
+
+    assert result["count"] == 250
+    assert [r["clientID"] for r in result["results"]] == list(range(250))
+    assert mock_session.request.call_count == 3
+
+
+def test_search_entities_dedupes_by_unique_key(netzero_api, mock_session):
+    # Page boundary shift: id 99 appears on both page 1 and page 2
+    dataset = [{"clientID": i} for i in range(100)] + [{"clientID": 99}] + [
+        {"clientID": i} for i in range(100, 149)
+    ]
+    mock_session.request.side_effect = _search_responder(total=150, dataset=dataset)
+
+    result = netzero_api._search_entities(
+        endpoint="companies",
+        filter=MainFilter(),
+        page_size=100,
+        unique_key="clientID",
+    )
+
+    client_ids = [r["clientID"] for r in result["results"]]
+    assert len(client_ids) == len(set(client_ids))
+    assert result["count"] == 149
+
+
+def test_retry_on_500(netzero_api, mock_session):
+    mock_session.request.side_effect = [
+        _response(status=500),
+        _response({"count": 1, "results": [{"clientID": 1}]}),
+    ]
+
+    with patch("vdl_tools.scrape_enrich.netzero_insights.netzero_api.time.sleep"):
+        result = netzero_api._search_entities(endpoint="companies", limit=1)
+
+    assert result["count"] == 1
+    assert mock_session.request.call_count == 2
+
+
+def test_reauth_on_401(netzero_api, mock_session):
+    mock_session.post.reset_mock()
+    mock_session.post.return_value = _response()  # the re-login call
+    mock_session.request.side_effect = [
+        _response(status=401),
+        _response({"count": 1, "results": [{"clientID": 1}]}),
+    ]
+
+    result = netzero_api._search_entities(endpoint="companies", limit=1)
+
+    assert result["count"] == 1
+    # 401 triggered exactly one re-login before the retry succeeded
+    mock_session.post.assert_called_once()
+    assert netzero_api._auth_generation == 1
+
+
+def test_persistent_401_raises(netzero_api, mock_session):
+    mock_session.post.return_value = _response()
+    mock_session.request.side_effect = [_response(status=401)] * 5
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        netzero_api._search_entities(endpoint="companies", limit=1)
+
+
+class TestSearchCheckpoint:
+
+    def _run_search(self, netzero_api, tmp_path, **kwargs):
+        return netzero_api._search_entities(
+            endpoint="companies",
+            filter=MainFilter(),
+            sorting=Sorting(field="clientID"),
+            page_size=100,
+            checkpoint_dir=str(tmp_path),
+            **kwargs,
         )
-        mock_aiohttp_session.get.return_value.__aenter__.return_value.raise_for_status = AsyncMock()
 
-        with patch('aiohttp.ClientSession', return_value=mock_aiohttp_session):
-            results = await netzero_api._get_details_batch(
+    def test_checkpoint_writes_pages_and_meta(self, netzero_api, mock_session, tmp_path):
+        mock_session.request.side_effect = _search_responder(total=250)
+
+        result = self._run_search(netzero_api, tmp_path)
+
+        assert result["count"] == 250
+        search_dirs = list(tmp_path.iterdir())
+        assert len(search_dirs) == 1
+        files = {f.name for f in search_dirs[0].iterdir()}
+        assert "meta.json" in files
+        assert len([f for f in files if f.startswith("page_")]) == 3
+
+    def test_full_resume_makes_no_requests(self, netzero_api, mock_session, tmp_path):
+        mock_session.request.side_effect = _search_responder(total=250)
+        first = self._run_search(netzero_api, tmp_path)
+
+        mock_session.request.reset_mock()
+        mock_session.request.side_effect = AssertionError("should not hit the API")
+        resumed = self._run_search(netzero_api, tmp_path)
+
+        assert resumed["results"] == first["results"]
+        assert mock_session.request.call_count == 0
+
+    def test_partial_resume_fetches_only_missing_pages(self, netzero_api, mock_session, tmp_path):
+        mock_session.request.side_effect = _search_responder(total=250)
+        first = self._run_search(netzero_api, tmp_path)
+
+        # Simulate dying before the middle page was persisted
+        search_dir = next(tmp_path.iterdir())
+        (search_dir / "page_000000100.json.gz").unlink()
+
+        mock_session.request.reset_mock()
+        mock_session.request.side_effect = _search_responder(total=250)
+        resumed = self._run_search(netzero_api, tmp_path)
+
+        assert resumed["results"] == first["results"]
+        assert mock_session.request.call_count == 1
+
+    def test_stale_checkpoint_is_refetched(self, netzero_api, mock_session, tmp_path):
+        mock_session.request.side_effect = _search_responder(total=250)
+        self._run_search(netzero_api, tmp_path)
+
+        meta_path = next(tmp_path.iterdir()) / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta["created_at"] = (
+            datetime.now(timezone.utc) - timedelta(days=10)
+        ).isoformat()
+        meta_path.write_text(json.dumps(meta))
+
+        mock_session.request.reset_mock()
+        mock_session.request.side_effect = _search_responder(total=250)
+        result = self._run_search(netzero_api, tmp_path)
+
+        assert result["count"] == 250
+        assert mock_session.request.call_count == 3
+
+    def test_different_query_uses_different_checkpoint(self, netzero_api, mock_session, tmp_path):
+        mock_session.request.side_effect = _search_responder(total=250)
+        self._run_search(netzero_api, tmp_path)
+
+        mock_session.request.reset_mock()
+        mock_session.request.side_effect = _search_responder(total=250)
+        netzero_api._search_entities(
+            endpoint="companies",
+            filter=MainFilter(include={"name": "different"}),
+            sorting=Sorting(field="clientID"),
+            page_size=100,
+            checkpoint_dir=str(tmp_path),
+        )
+
+        # New query hash -> fresh fetch, second checkpoint dir
+        assert mock_session.request.call_count == 3
+        assert len(list(tmp_path.iterdir())) == 2
+
+
+class _FakeAiohttpResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+class _FakeCM:
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def test_get_details_batch(netzero_api, mock_session):
+    mock_session.cookies.get_dict.return_value = {"JSESSIONID": "abc"}
+
+    fake_http_session = Mock()
+    fake_http_session.get = Mock(
+        side_effect=lambda url, **kwargs: _FakeCM(
+            _FakeAiohttpResponse({"clientID": int(url.rsplit("/", 1)[1]), "name": "Test"})
+        )
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_FakeCM(fake_http_session)):
+        results = asyncio.run(
+            netzero_api._get_details_batch(
                 ids=[1, 2],
                 endpoint="getStartup",
-                model_class=Startup
+                model_class=Startup,
+                read_from_cache=False,
+                write_to_cache=False,
             )
+        )
 
-            assert len(results) == 2
-            assert results[0]["id"] == 1
-            assert results[0]["name"] == "Test Startup"
+    assert len(results) == 2
+    assert {r["clientID"] for r in results} == {1, 2}
+    assert all(r["fullData"]["name"] == "Test" for r in results)
 
-def test_get_startup_detail(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.json.return_value = {"id": 1, "name": "Test Startup"}
-    mock_response.raise_for_status.return_value = None
-    mock_session.get.return_value = mock_response
 
-    with patch('vdl_tools.shared_tools.database_cache.database_utils.get_session') as mock_get_session:
-        mock_db_session = Mock()
-        mock_get_session.return_value.__enter__.return_value = mock_db_session
-        mock_db_session.query.return_value.filter.return_value.first.return_value = None
+def test_get_details_batch_reauths_on_401(netzero_api, mock_session):
+    mock_session.cookies.get_dict.return_value = {"JSESSIONID": "abc"}
+    mock_session.post.reset_mock()
+    mock_session.post.return_value = _response()  # re-login
 
-        result = netzero_api.get_startup_detail(startup_id=1)
+    calls = {"n": 0}
 
-        assert result["id"] == 1
-        assert result["name"] == "Test Startup"
+    def get_side_effect(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _FakeCM(_FakeAiohttpResponse({}, status=401))
+        return _FakeCM(_FakeAiohttpResponse({"clientID": 1, "name": "Test"}))
 
-def test_cache_handling(netzero_api, mock_session):
-    # Mock database session with cached result
-    with patch('vdl_tools.shared_tools.database_cache.database_utils.get_session') as mock_get_session:
-        mock_db_session = Mock()
-        mock_get_session.return_value.__enter__.return_value = mock_db_session
-        
-        # Create a mock cached startup
-        mock_cached_startup = Mock()
-        mock_cached_startup.to_dict.return_value = {"id": 1, "name": "Cached Startup"}
-        mock_db_session.query.return_value.filter.return_value.first.return_value = mock_cached_startup
+    fake_http_session = Mock()
+    fake_http_session.get = Mock(side_effect=get_side_effect)
 
-        result = netzero_api.get_startup_detail(startup_id=1, read_from_cache=True)
+    with patch("aiohttp.ClientSession", return_value=_FakeCM(fake_http_session)):
+        results = asyncio.run(
+            netzero_api._get_details_batch(
+                ids=[1],
+                endpoint="getStartup",
+                model_class=Startup,
+                read_from_cache=False,
+                write_to_cache=False,
+            )
+        )
 
-        assert result["id"] == 1
-        assert result["name"] == "Cached Startup"
-        # Verify API was not called
-        mock_session.get.assert_not_called()
-
-def test_error_handling(netzero_api, mock_session):
-    mock_response = Mock()
-    mock_response.raise_for_status.side_effect = requests.exceptions.RequestException("API Error")
-    mock_session.get.return_value = mock_response
-
-    with pytest.raises(requests.exceptions.RequestException):
-        netzero_api.get_startup_detail(startup_id=1) 
+    assert len(results) == 1
+    mock_session.post.assert_called_once()


### PR DESCRIPTION
## What changed

`search_companies` fetched pages one at a time with no retries, holding all results in memory — a process dying at page 400 of 500 lost everything and restarted from page 1. This PR makes the search path resilient and concurrent, and speeds up the details phase.

### Resilience
- **Per-page search checkpoints** (`SearchCheckpoint` in `netzero_api.py`): each fetched page is persisted via `json_cache` (local path or `s3://`) under a directory keyed by a sha256 of the full query payload (endpoint + filter + sorting + page_size). Re-running the same query resumes from the completed pages; a changed query hashes to a different directory, so a checkpoint can never be resumed against the wrong query. The persisted payload doubles as a lineage record of exactly which query produced which results. Checkpoints older than 7 days are refetched (`checkpoint_max_age_days`).
- `search_companies` checkpoints **by default** to `~/.cache/vdl-tools/nzi_search` (override with `NZI_SEARCH_CHECKPOINT_DIR`; disable with `checkpoint_dir=None`).
- **Retries with backoff + jitter** for 429/5xx/connection errors on both the sync (`_request_with_retries`) and aiohttp (`_get_details_batch`) paths — previously only timeouts retried, and the search path had no retries at all.
- **Re-auth on 401/403**: the session cookie expires on multi-hour runs; both paths now re-login once and retry, with a lock + generation counter so N concurrent 401s cause exactly one re-login.

### Speed
- **Concurrent page fetches**: page 1 establishes `total_count`, remaining offsets fetch in parallel (default 8, `max_concurrent_pages`). Results are deduped by `clientID`/`investorID` in case rows shift between pages.
- **Details stages gathered**: `get_full_details_from_company_ids` runs startup details + funding rounds + commercial deals in one `asyncio.gather` instead of serial `asyncio.run` calls (investors still sequence after funding rounds, which they depend on).

### Bug fixes
- `max_pages = limit // page_size` truncated results (`limit=250` returned 200); now `ceil` + exact truncation.
- `UnboundLocalError` when `_search_entities` was called with no filter.
- Removed `_paginate` (superseded; only its own test used it).

## Tests

`test_netzero_api.py` rewritten — 6 of its 10 tests already failed on main against methods that no longer exist. Now 19 passing tests covering the checkpoint lifecycle (write, full resume with zero HTTP calls, partial resume, staleness, query isolation), 500-retry, 401 re-auth (sync + async), persistent-401 raising, dedupe, and the limit fix. A separate smoke test verified the gathered detail stages actually overlap and investors sequence after funding.

The 27 failures in `test_nzi_funding_round_processing.py` pre-date this branch (verified against the stashed tree) and are unrelated.

## Reviewer notes

- **No default sort order is applied.** I couldn't verify which sort field names the NZI API accepts without live calls, so a checkpointed search without explicit `sorting` logs a warning instead of guessing. Worth one live check (`Sorting(field="clientID")`) — if the API accepts it, we should make it the default for checkpointed searches.
- Unit tests mock all HTTP. Before a large production crawl, do one small live run to confirm the API tolerates 8 concurrent page fetches.
- Peak API concurrency for gathered detail stages is a small multiple of `max_concurrent_requests` (each stage gets its own semaphore); defaults kept conservative (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
