### PR TITLE
Separate cache model_name from the API model; add reasoning to classi…

### DIFF
--- a/vdl_tools/shared_tools/openai/openai_constants.py
+++ b/vdl_tools/shared_tools/openai/openai_constants.py
@@ -1,4 +1,11 @@
 MODEL_DATA = {
+    "gpt-5-mini": {
+        "model_name": "gpt-5-mini",
+        "max_context_window": 400_000,
+        "max_output_tokens": 128_000,
+        "input_cost_per_token": 0.25 / 1_000_000,
+        "output_cost_per_token": 2.0 / 1_000_000,
+    },
     "gpt-5.5": {
         "model_name": "gpt-5.5",
         "max_context_window": 1_000_000,

--- a/vdl_tools/shared_tools/openai/prompt_response_cache_instructor.py
+++ b/vdl_tools/shared_tools/openai/prompt_response_cache_instructor.py
@@ -65,6 +65,7 @@ class InstructorPRC(PromptResponseCacheSQL):
         model=DEFAULT_MODEL,
         filter_by_model=False,
         store_results=True,
+        cache_model_name: str | None = None,
     ):
         """Initialize the cache with a prompt and Pydantic response model.
 
@@ -92,6 +93,9 @@ class InstructorPRC(PromptResponseCacheSQL):
             If True, cache is scoped by model name. Default is False.
         store_results : bool, optional
             If True, persist responses to the database. Default is True.
+        cache_model_name : str, optional
+            Overrides the ``model_name`` used for cache keying while the API
+            is still called with ``model``. See ``PromptResponseCacheSQL``.
         """
         # If None or "" is passed in
         prompt_str_w_schema = f"{prompt_str}\n{response_model.schema_json()}"
@@ -103,6 +107,7 @@ class InstructorPRC(PromptResponseCacheSQL):
             filter_by_model=filter_by_model,
             model=model,
             store_results=store_results,
+            cache_model_name=cache_model_name,
         )
         self.prompt_text = prompt_str
         self.response_model = response_model

--- a/vdl_tools/shared_tools/openai/prompt_response_cache_sql.py
+++ b/vdl_tools/shared_tools/openai/prompt_response_cache_sql.py
@@ -210,6 +210,7 @@ class PromptResponseCacheSQL():
         filter_by_model: bool = False,
         model=DEFAULT_MODEL,
         store_results = True,
+        cache_model_name: str | None = None,
     ):
         """Initialize the cache for a given prompt and model.
 
@@ -241,6 +242,13 @@ class PromptResponseCacheSQL():
             so they can be returned from cache on future requests. If False,
             results are returned but not stored (no cache fill). Default is
             True.
+        cache_model_name : str, optional
+            When set, this string (not ``model``) is used as the cache row's
+            ``model_name`` for reads/writes, while ``model`` is still what the
+            API is actually called with. This lets otherwise-identical calls
+            that differ only in API kwargs (e.g. ``reasoning`` effort) live in
+            separate cache namespaces without changing the model-facing prompt.
+            Defaults to ``model``.
 
         Raises
         ------
@@ -260,6 +268,10 @@ class PromptResponseCacheSQL():
         )
         self.filter_by_model = filter_by_model
         self.model = model
+        # Cache-key model name: defaults to the API model, but can be tagged
+        # (e.g. "gpt-5.4-mini#reasoning=low") to separate cache rows for calls
+        # that share prompt + model but differ in API kwargs.
+        self.cache_model_name = cache_model_name or model
         self.store_results = store_results
 
         context_window, max_output_tokens = get_context_window(self.model)
@@ -365,7 +377,7 @@ class PromptResponseCacheSQL():
                 PromptResponse.given_id == given_id,
         ]
         if self.filter_by_model:
-            filters.append(PromptResponse.model_name == self.model)
+            filters.append(PromptResponse.model_name == self.cache_model_name)
 
         prompt_response_obj = (
             self.session
@@ -408,7 +420,7 @@ class PromptResponseCacheSQL():
         ]
 
         if self.filter_by_model:
-            filters.append(PromptResponse.model_name == self.model)
+            filters.append(PromptResponse.model_name == self.cache_model_name)
 
         found_rows = (
             self.session
@@ -452,7 +464,7 @@ class PromptResponseCacheSQL():
         return {
             "prompt_id": self.prompt.id,
             "given_id": str(given_id),
-            "model_name": self.model,
+            "model_name": self.cache_model_name,
             "text_id": text_id,
             "input_text": text,
             "response_full": response.model_dump_json(),
@@ -476,7 +488,7 @@ class PromptResponseCacheSQL():
         return {
             "prompt_id": self.prompt.id,
             "given_id": str(given_id),
-            "model_name": self.model,
+            "model_name": self.cache_model_name,
             "text_id": text_id,
             "input_text": text,
             "response_full": response_full,

--- a/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/hierarchical_taxonomy_mapping.py
@@ -621,6 +621,8 @@ def classify_entities(
     match_schema: type[BaseModel] | None = None,
     temperature: float | None = 0,
     filter_by_model: bool = False,
+    reasoning: dict | None = None,
+    cache_model_name: str | None = None,
 ) -> pd.DataFrame:
     """Classify many entities against the taxonomy via a SQL-cached walk.
 
@@ -722,6 +724,18 @@ def classify_entities(
         this True whenever you run more than one model against the same
         taxonomy**, otherwise a model switch silently reuses the prior
         model's cached results.
+    reasoning
+        Optional reasoning config forwarded to the Responses API for
+        reasoning models (``gpt-5*``), e.g. ``{"effort": "low"}``. Ignored
+        for non-reasoning models (they reject it). When omitted, the model's
+        own default effort applies — note that differs by model (``gpt-5-mini``
+        defaults to medium, ``gpt-5.4-mini`` to none).
+    cache_model_name
+        Optional override for the cache row's ``model_name`` (see
+        ``PromptResponseCacheSQL``). The API is still called with ``model``;
+        this only tags the cache namespace. Use it with ``filter_by_model=True``
+        to keep otherwise-identical runs that differ only in ``reasoning``
+        effort in separate cache rows (e.g. ``"gpt-5.4-mini#reasoning=low"``).
     """
     levels = normalize_levels(levels)
     last_idx = levels[-1]["idx"]
@@ -736,6 +750,23 @@ def classify_entities(
     api_kwargs: dict[str, Any] = {}
     if temperature is not None and not is_reasoning_model(model):
         api_kwargs["temperature"] = temperature
+    # Reasoning effort (e.g. {"effort": "low"}) only applies to reasoning
+    # models; pass it through to responses.parse for those. Non-reasoning
+    # models reject it, so it's guarded like temperature above.
+    if reasoning is not None and is_reasoning_model(model):
+        api_kwargs["reasoning"] = reasoning
+    elif reasoning is None and is_reasoning_model(model):
+        # The effort actually used is then the model's own default, which
+        # varies by model (gpt-5-mini: medium, gpt-5.4-mini: none) and is not
+        # recorded in the cache key — so runs at different efforts would
+        # collide. Warn rather than assume a default: the defaults are
+        # OpenAI's to change, and a key asserting the wrong effort is worse
+        # than none. Pass `reasoning` + `cache_model_name` to pin it.
+        logger.warning(
+            f"No reasoning effort set for {model} — the model's own default "
+            f"applies and is NOT part of the cache key. Review whether that "
+            f"is intended; set reasoning={{'effort': ...}} to pin it."
+        )
 
     logger.info(f"Classifying {len(entities)} entities (cached, level-batched)")
     t0 = time.time()
@@ -746,6 +777,7 @@ def classify_entities(
         model=model,
         response_model=response_model,
         filter_by_model=filter_by_model,
+        cache_model_name=cache_model_name,
     )
 
     # Initialize one branch per entity. Carry each input row's columns

--- a/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/taxonomy_mapping_cache.py
@@ -143,6 +143,7 @@ class TaxonomyMatchCache(InstructorPRC):
         store_results: bool = True,
         filter_by_model: bool = False,
         response_model: type[BaseModel] = MatchesResponse,
+        cache_model_name: str | None = None,
     ):
         super().__init__(
             session=session,
@@ -152,6 +153,7 @@ class TaxonomyMatchCache(InstructorPRC):
             model=model,
             filter_by_model=filter_by_model,
             store_results=store_results,
+            cache_model_name=cache_model_name,
         )
 
 


### PR DESCRIPTION
…fy_entities

Reasoning effort changes the response but is not part of the cache key (prompt_id, given_id, model_name), so two runs differing only in effort collide. Add an optional cache_model_name that tags the cache row while the API is still called with the real model, letting a run be namespaced as e.g. "gpt-5.4-mini#reasoning=medium".

- prompt_response_cache_sql: cache_model_name param, applied at the four cache-key sites only; self.model still drives the API call and token sizing.
- prompt_response_cache_instructor / taxonomy_mapping_cache: forward it through.
- hierarchical_taxonomy_mapping: reasoning + cache_model_name on classify_entities, both guarded on is_reasoning_model. Warn when a reasoning model runs with no explicit effort, since the model's silent default then applies and is not recorded in the key (gpt-5-mini defaults to medium, gpt-5.4-mini to none). Warn rather than assume a default table: the defaults are OpenAI's to change, and a key asserting the wrong effort is worse than none.
- openai_constants: add the gpt-5-mini MODEL_DATA entry get_context_window needs.

All new params are optional and default to existing behavior.