### PR TITLE
Generalize the primary-category prompt for n-level taxonomies

### DIFF
--- a/vdl_tools/shared_tools/taxonomy_mapping/primary_category_selection.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/primary_category_selection.py
@@ -26,7 +26,7 @@ PRIMARY_CATEGORY_PROMPT = dedent("""\
 
     Rules:
     - Choose the category aligned with the org's central mission, not a secondary activity
-    - Prefer more specific categories (solutions) over broader ones when the org clearly fits
+    - When two categories describe the mission equally well, prefer the more specific (deeper) one
     - If a website URL is provided, you may use web search to gather additional evidence
     - Return ONLY the exact category name as it appears in the input
 """).strip()

--- a/vdl_tools/shared_tools/taxonomy_mapping/primary_category_selection.py
+++ b/vdl_tools/shared_tools/taxonomy_mapping/primary_category_selection.py
@@ -5,11 +5,26 @@ module provides an LLM-backed step that picks the single category that best
 represents the org's primary mission.  The result is stored in the SQL cache
 so repeat runs with the same org/category set are served without hitting the
 API.
+
+Two front-ends share that one cached LLM call — same prompt, response model,
+``_format_user_message``, ``PrimaryCategoryCache``, and cache-key convention —
+differing only in how they marshal candidates in and map the answer back out:
+
+  - ``run_primary_category_selection`` — the flat-taxonomy pipeline. Candidates
+    are single category *names*; input is a per-match frame with a ``pct``
+    similarity column; the pick is written back as an ``is_llm_primary`` boolean
+    and the fallback (on an unrecognised answer) is the highest-``pct`` match.
+  - ``make_llm_primary_strategy`` — the hierarchical engine. A factory that
+    returns a ``select_primary_paths`` strategy callable; candidates are full
+    root→leaf *paths* (node names repeat across branches, only the path is
+    unique); it returns a one-row-per-id primary-path frame and the fallback is
+    the deepest path (no similarity scores exist in an LLM walk).
 """
 
 import json
 from textwrap import dedent
 
+import pandas as pd
 from pydantic import BaseModel
 
 from vdl_tools.shared_tools.database_cache.database_utils import get_session
@@ -294,3 +309,235 @@ def run_primary_category_selection(
                 all_df.loc[fallback_idx, 'is_llm_primary'] = True
 
     return all_df
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical taxonomy: primary-path selection as a select_primary_paths hook
+# ---------------------------------------------------------------------------
+
+DEFAULT_HIERARCHICAL_PRIMARY_API_KWARGS = {"reasoning": {"effort": "medium"}}
+
+
+def _clean_cell(v):
+    """None/NaN/blank -> None; else stripped str. (NaN is truthy — never use
+    ``v or ''`` on frame values that round-tripped through xlsx.)"""
+    if v is None or pd.isna(v):
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+def _row_path_depth(row, output_cols: list[str]) -> int:
+    """0-based depth of the deepest non-empty level; -1 for no match.
+
+    Mirrors ``hierarchical_taxonomy_mapping._path_depth`` so the fallback
+    ranking matches ``select_primary_paths(strategy="deepest")`` exactly.
+    """
+    depth = -1
+    for i, col in enumerate(output_cols):
+        if _clean_cell(row.get(col)) is not None:
+            depth = i
+    return depth
+
+
+def _row_path_str(row, output_cols: list[str]) -> str:
+    parts = [_clean_cell(row.get(col)) for col in output_cols]
+    return " > ".join(p for p in parts if p)
+
+
+def make_llm_primary_strategy(
+    *,
+    text_col: str,
+    name_col: str | None = None,
+    model: str = DEFAULT_MODEL,
+    llm_api_kwargs: dict | None = None,
+    max_workers: int = 16,
+    use_cached_results: bool = True,
+    filter_by_model: bool = True,
+):
+    """Build a ``select_primary_paths`` strategy callable that picks the primary
+    path with an LLM for multi-path orgs (hierarchical-taxonomy successor of
+    ``run_primary_category_selection``).
+
+    Pass the returned callable as ``primary=`` to
+    ``add_hierarchical_taxonomy_mapping`` (or straight to
+    ``select_primary_paths``). Per org: no matched path -> null row
+    (``cat_level = pd.NA``); exactly one path -> that path, no API call; two or
+    more -> ``model`` (SQL-cached ``PrimaryCategoryCache``) picks the org's
+    primary mission, with an unrecognised/missing answer falling back to the
+    deepest path.
+
+    ``name_col`` / ``text_col`` name columns of the *per-row mapping frame*
+    (``classify_entities`` carries every input column through). ``llm_api_kwargs``
+    defaults to ``DEFAULT_HIERARCHICAL_PRIMARY_API_KWARGS``
+    (``reasoning=medium``) and is forwarded to the API. ``filter_by_model=True``
+    keeps cache rows separate per model identity so model comparisons don't
+    reuse each other's picks.
+    """
+    api_kwargs = dict(
+        DEFAULT_HIERARCHICAL_PRIMARY_API_KWARGS
+        if llm_api_kwargs is None
+        else llm_api_kwargs
+    )
+
+    def _strategy(
+        per_row_mapping_df: pd.DataFrame, levels: list[dict], id_col: str
+    ) -> pd.DataFrame:
+        output_cols = [lvl["output_col"] for lvl in levels]
+        work = per_row_mapping_df.reset_index(drop=True)
+
+        # Per org: dedup matched paths (walk order preserved), split into
+        # no-match / single / multi.
+        ids_to_payloads: dict[str, dict] = {}
+        ids_to_texts: dict[str, str] = {}
+        # org_id -> {"candidates": [cand...], "chosen": cand | None}
+        org_state: dict = {}
+
+        n_single = n_multi = 0
+        for org_id, group in work.groupby(id_col, sort=False):
+            candidates = []
+            seen_paths = set()
+            for _, row in group.iterrows():
+                depth = _row_path_depth(row, output_cols)
+                if depth < 0:
+                    continue
+                path = _row_path_str(row, output_cols)
+                if path in seen_paths:
+                    continue
+                seen_paths.add(path)
+                candidates.append(
+                    {
+                        "path": path,
+                        "depth": depth,
+                        "levels": {c: _clean_cell(row.get(c)) for c in output_cols},
+                        "definition": _clean_cell(row.get("leaf_definition")) or "",
+                    }
+                )
+
+            state = {"candidates": candidates, "chosen": None}
+            org_state[org_id] = state
+            if not candidates:
+                continue
+            if len(candidates) == 1:
+                state["chosen"] = candidates[0]
+                n_single += 1
+                continue
+
+            n_multi += 1
+            first = group.iloc[0]
+            sorted_cands = sorted(candidates, key=lambda c: c["path"])
+            given_id = f"{org_id}|" + "|".join(c["path"] for c in sorted_cands)
+            payload = {
+                "org_id": org_id,
+                "org_name": (
+                    str(first[name_col])
+                    if name_col and name_col in group.columns
+                    else None
+                ),
+                "org_description": (
+                    str(first[text_col]) if text_col in group.columns else ""
+                ),
+                "categories": [
+                    {
+                        "name": c["path"],  # full path = unambiguous map-back key
+                        "level0": c["levels"].get(output_cols[0]) or "",
+                        "level1": (
+                            c["levels"].get(output_cols[1]) or ""
+                            if len(output_cols) > 1
+                            else ""
+                        ),
+                        "level2": (
+                            c["levels"].get(output_cols[2]) or ""
+                            if len(output_cols) > 2
+                            else ""
+                        ),
+                        "definition": c["definition"],
+                    }
+                    for c in sorted_cands
+                ],
+            }
+            ids_to_payloads[given_id] = payload
+            ids_to_texts[given_id] = _format_user_message(payload)
+
+        logger.info(
+            "LLM primary selection: %d orgs (%d single-path, %d multi-path -> %s)",
+            len(org_state), n_single, n_multi, model,
+        )
+
+        # One bulk, SQL-cached call for every multi-path org.
+        n_fallback = 0
+        if ids_to_texts:
+            with get_session() as session:
+                cache = PrimaryCategoryCache(
+                    session=session, model=model, filter_by_model=filter_by_model
+                )
+                responses = cache.bulk_get_cache_or_run(
+                    given_ids_texts=list(ids_to_texts.items()),
+                    use_cached_result=use_cached_results,
+                    max_workers=max_workers,
+                    **api_kwargs,
+                )
+
+            for given_id, payload in ids_to_payloads.items():
+                org_id = payload["org_id"]
+                state = org_state[org_id]
+                response_dict = (responses or {}).get(given_id) or {}
+                response_text = response_dict.get("response_text")
+                try:
+                    primary_name = (
+                        json.loads(response_text).get("primary_category_name")
+                        if response_text
+                        else None
+                    )
+                except (json.JSONDecodeError, TypeError):
+                    primary_name = None
+
+                answer = (primary_name or "").strip()
+                chosen = next(
+                    (c for c in state["candidates"] if c["path"] == answer), None
+                )
+                if chosen is None and answer:
+                    # Models sometimes return just the leaf node name instead of
+                    # the full path — accept it when it's unambiguous.
+                    leaf_matches = [
+                        c
+                        for c in state["candidates"]
+                        if c["path"].split(" > ")[-1] == answer
+                    ]
+                    if len(leaf_matches) == 1:
+                        chosen = leaf_matches[0]
+                if chosen is None:
+                    # Missing/hallucinated response -> deepest fallback (max
+                    # depth, first in walk order on ties).
+                    n_fallback += 1
+                    logger.warning(
+                        "Primary path %r not in accepted set for org %s; "
+                        "falling back to deepest.", primary_name, org_id,
+                    )
+                    chosen = max(state["candidates"], key=lambda c: c["depth"])
+                state["chosen"] = chosen
+
+        if n_fallback:
+            logger.warning(
+                "LLM primary selection: %d/%d multi-path orgs fell back to deepest.",
+                n_fallback, n_multi,
+            )
+
+        # Assemble the hook's contract frame: one row per id, in first-seen
+        # order, columns [id_col, *output_cols, cat_level (Int64)].
+        rows = []
+        for org_id, state in org_state.items():
+            chosen = state["chosen"]
+            row = {id_col: org_id}
+            if chosen is None:
+                row.update({c: None for c in output_cols})
+                row["cat_level"] = pd.NA
+            else:
+                row.update({c: chosen["levels"].get(c) for c in output_cols})
+                row["cat_level"] = chosen["depth"]
+            rows.append(row)
+        primary = pd.DataFrame(rows)
+        primary["cat_level"] = primary["cat_level"].astype("Int64")
+        return primary
+
+    return _strategy


### PR DESCRIPTION
What
Two related changes to taxonomy_mapping/primary_category_selection.py, both enabling the hierarchical taxonomy engine to select an org's primary category with an LLM (the flat pipeline already could):

make_llm_primary_strategy (new) — a factory returning a select_primary_paths strategy callable. Pass it as primary= to add_hierarchical_taxonomy_mapping. Per org: no match → null row; single path → picked directly (no API); 2+ paths → the model picks the primary mission, falling back to the deepest path on an unrecognized answer. SQL-cached via the existing PrimaryCategoryCache.
Generalized PRIMARY_CATEGORY_PROMPT — one rule reworded:

```
- Prefer more specific categories (solutions) over broader ones when the org clearly fits
+ When two categories describe the mission equally well, prefer the more specific (deeper) one
```

The old rule was written for the climate taxonomy: "solutions" is that taxonomy's leaf-level name, and it encoded depth as a general preference.

Impact
No live consumer of the flat picker. run_primary_category_selection is disabled everywhere in the workspace (every caller passes run_primary_category_selection=False; the climate-landscape repo has no references). So no production behavior changes.
~~~~~
Needs to be tested in other pipelines