### PR TITLE
Fix aspect_ratio in multi-circle layout: coerce cluster center to mutable float array

### DIFF
--- a/vdl_tools/tag2network/Network/ClusterLayout.py
+++ b/vdl_tools/tag2network/Network/ClusterLayout.py
@@ -147,7 +147,9 @@ def compress_groups(nodes_df, layout_dict, cluster_attr, overlap_frac,
                 new_center = new_centers[clus]
                 # change plot aspect ratio - aspect > 1 -> stretch x-axis]
                 if aspect_ratio != 1.0:
-                    new_center = new_center.copy()
+                    # new_center may be a tuple (from `centers`, when overlap_frac==1.0)
+                    # or an ndarray (from _remove_overlap); coerce to a mutable float array
+                    new_center = np.array(new_center, dtype=float)
                     if aspect_ratio > 1.0:
                         new_center[0] = new_center[0] * aspect_ratio
                     else:


### PR DESCRIPTION
In compress_groups, the aspect_ratio != 1.0 branch called .copy() and did item-assignment on new_center. In the multicircle path overlap_frac is forced to 1.0, so new_centers are plain tuples, which have no .copy() and are immutable. Coerce to an np.array(dtype=float) so both operations work; also handles the ndarray case from _remove_overlap without regression.